### PR TITLE
Add a getter so that the websocket is accessible outside websock.js

### DIFF
--- a/include/websock.js
+++ b/include/websock.js
@@ -413,6 +413,7 @@ function constructor() {
     api.send         = send;
     api.send_string  = send_string;
 
+    api.getWebSocket = function() { return websocket; }
     api.on           = on;
     api.init         = init;
     api.open         = open;


### PR DESCRIPTION
I actually only need readyState, but I don't know what the point in hiding everything. If it's not a getter, it would need to be updated automatically on every readyState change, because JavaScript doesn't support C# style properties AFAIK.
