### PR TITLE
fix cygwin compilation

### DIFF
--- a/other/websockify.c
+++ b/other/websockify.c
@@ -16,6 +16,7 @@
 #include <netdb.h>
 #include <sys/select.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include "websocket.h"
 


### PR DESCRIPTION
When compiling under cygwin, access() constants are not defined in fcntl.h:

```
websockify.c: In function ‘main’:
websockify.c:368:35: error: ‘R_OK’ undeclared (first use in this function)
         if (access(settings.cert, R_OK) != 0) {
```

Including unistd.h allows compilation to complete.
