### PR TITLE
Added mechanism to ensure data send

### DIFF
--- a/include/websock.js
+++ b/include/websock.js
@@ -65,7 +65,8 @@ var api = {},         // Public API
         'error'   : function() {}
     },
 
-    test_mode = false;
+    test_mode = false,
+    sendDataFromQueueTimer = -1;
 
 
 //
@@ -209,9 +210,20 @@ function flush() {
 
 // overridable for testing
 function send(arr) {
+    var dataSentOk;
     //Util.Debug(">> send_array: " + arr);
     sQ = sQ.concat(arr);
-    return flush();
+    dataSentOk = flush();
+    if (dataSentOk === false && sendDataFromQueueTimer === -1) {
+        sendDataFromQueueTimer = setInterval(function () {
+            dataSentOk = flush();
+            if (dataSentOk === true) {
+                clearInterval(sendDataFromQueueTimer);
+                sendDataFromQueueTimer = -1;
+            }
+        }, 100);
+    }
+    return dataSentOk;
 }
 
 function send_string(str) {


### PR DESCRIPTION
Added mechanism to ensure data send in case that `websocket.bufferedAmunt > api.maxBufferedAmount`

Because sometimes when the `websocket.bufferedAmount > api.maxBufferedAmount` the `else` block of `flush` function was reached and eventually the websokets got closed, and that _mechanism with the `setInterval`_ is the only way that I managed to keep the connection alive and working.

Daniel.
