### PR TITLE
Switch to using ssl.create_default_context 

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -815,11 +815,12 @@ class WebSocketServer(object):
                                   % self.cert)
             retsock = None
             try:
-                retsock = ssl.wrap_socket(
+                context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+                context.load_cert_chain(self.cert, self.key)
+
+                retsock = context.wrap_socket(
                         sock,
-                        server_side=True,
-                        certfile=self.cert,
-                        keyfile=self.key)
+                        server_side=True)
             except ssl.SSLError:
                 _, x, _ = sys.exc_info()
                 if x.args[0] == ssl.SSL_ERROR_EOF:


### PR DESCRIPTION
The default settings that you get with ssl.wrap_socket are very insecure.  They support SSLv2 and SSLv3, and do not provide any ciphers supporting forward secrecy.

Prior to these changes, a websockify server gets a 'C' grade on the ssllabs test.  It's also vulnerable to POODLE.

After these changes, it now gets an 'A' grade, as well as supporting forward secrecy.

The downside here is that this would drop support for anything lower then Python 2.7.9.

I'm relying on a ssl module function here to pick secure defaults, so this shouldn't require chasing a moving target: https://docs.python.org/2.7/library/ssl.html#ssl.create_default_context
