### PR TITLE
Make numpy an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ setup(name=name,
 
       packages=['websockify'],
       include_package_data=True,
-      install_requires=['numpy'],
+      extras_require = {
+          'fastHyBi': ['numpy']
+      },
       zip_safe=False,
       entry_points={
         'console_scripts': [


### PR DESCRIPTION
The code in `websocket.py` is able to work without numpy being installed,
but numpy is specified as a hard dependency in `setup.py`.

This change moves numpy to `extras_require` section.
To install websockify with fast HyBi support, one should install it with

`pip install websockify[fastHyBi]`

to have numpy also automatically installed.
