### PR TITLE
split header and data functions

### DIFF
--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -409,9 +409,11 @@ class HyBiEncodeDecodeTestCase(unittest.TestCase):
 
     def test_encode_hybi_basic(self):
         res = websocket.WebSocketRequestHandler.encode_hybi(b'Hello', 0x1)
-        expected = (b'\x81\x05\x48\x65\x6c\x6c\x6f', 2, 0)
+        expected_header = (b'\x81\x05')
+        expected_data = (b'\x48\x65\x6c\x6c\x6f')
 
-        self.assertEqual(res, expected)
+        self.assertEqual(res[0], expected_header)
+        self.assertEqual(res[1], expected_data)
 
     def test_strict_mode_refuses_unmasked_client_frames(self):
         buf = b'\x81\x05\x48\x65\x6c\x6c\x6f'

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -327,21 +327,7 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
                     opcode = 1
                 else:
                     opcode = 2
-                encbufs = self.send_hybi(buf, opcode, base64=self.base64, record=self.rec)
-
-        while self.send_parts:
-            # Send pending frames
-            buf = self.send_parts.pop(0)
-            sent = self.request.send(buf)
-
-            if sent == len(buf):
-                self.print_traffic("<")
-            else:
-                self.print_traffic("<.")
-                self.send_parts.insert(0, buf[sent:])
-                break
-
-        return len(self.send_parts)
+                self.send_hybi(buf, opcode, base64=self.base64, record=self.rec)
 
     def recv_frames(self):
         """ Receive and decode WebSocket frames.
@@ -494,7 +480,6 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
             # Indicate to server that a Websocket upgrade was done
             self.server.ws_connection = True
             # Initialize per client settings
-            self.send_parts = []
             self.recv_part  = None
             self.start_time = int(time.time()*1000)
 

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -154,8 +154,8 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
             return data.tostring()
 
     @staticmethod
-    def encode_hybi(buf, opcode, base64=False):
-        """ Encode a HyBi style WebSocket frame.
+    def encode_hybi_header(payload_len, opcode):
+        """ Encode a HyBi style WebSocket frame header.
         Optional opcode:
             0x0 - continuation
             0x1 - text frame (base64 encode buf)
@@ -164,21 +164,34 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
             0x9 - ping
             0xA - pong
         """
+        b1 = 0x80 | (opcode & 0x0f) # FIN + opcode
+        if payload_len <= 125:
+            return pack('>BB', b1, payload_len)
+        elif payload_len > 125 and payload_len < 65536:
+            return pack('>BBH', b1, 126, payload_len)
+        else:
+            assert payload_len >= 65536
+            return pack('>BBQ', b1, 127, payload_len)
+
+    @staticmethod
+    def encode_hybi(buf, opcode, base64=False):
+        """ Encode a HyBi style WebSocket frame. """
         if base64:
             buf = b64encode(buf)
+        header = WebSocketRequestHandler.encode_hybi_header(len(buf), opcode)
+        return (header, buf)
 
-        b1 = 0x80 | (opcode & 0x0f) # FIN + opcode
-        payload_len = len(buf)
-        if payload_len <= 125:
-            header = pack('>BB', b1, payload_len)
-        elif payload_len > 125 and payload_len < 65536:
-            header = pack('>BBH', b1, 126, payload_len)
-        elif payload_len >= 65536:
-            header = pack('>BBQ', b1, 127, payload_len)
+    def send_hybi(self, buf, opcode, base64=False, record=None):
+        """ Send a HyBi style WebSocket frame. """
+        header, buf = self.encode_hybi(buf, opcode, base64)
+        if record:
+            record.write("%s,\n" % repr("{%s{" % tdelta + encbufs[1]))
+        if len(buf)<=4096:
+            self.request.send(header+buf)
+        else:
+            self.request.send(header)
+            self.request.send(buf)
 
-        #self.msg("Encoded: %s", repr(header + buf))
-
-        return header + buf, len(header), 0
 
     @staticmethod
     def decode_hybi(buf, base64=False, logger=None, strict=True):
@@ -311,16 +324,10 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
         if bufs:
             for buf in bufs:
                 if self.base64:
-                    encbuf, lenhead, lentail = self.encode_hybi(buf, opcode=1, base64=True)
+                    opcode = 1
                 else:
-                    encbuf, lenhead, lentail = self.encode_hybi(buf, opcode=2, base64=False)
-
-                if self.rec:
-                    self.rec.write("%s,\n" %
-                            repr("{%s{" % tdelta
-                                + encbuf[lenhead:len(encbuf)-lentail]))
-
-                self.send_parts.append(encbuf)
+                    opcode = 2
+                encbufs = self.send_hybi(buf, opcode, base64=self.base64, record=self.rec)
 
         while self.send_parts:
             # Send pending frames
@@ -412,18 +419,15 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
         """ Send a WebSocket orderly close frame. """
 
         msg = pack(">H%ds" % len(reason), code, s2b(reason))
-        buf, h, t = self.encode_hybi(msg, opcode=0x08, base64=False)
-        self.request.send(buf)
+        self.send_hybi(msg, opcode=0x08)
 
     def send_pong(self, data=''):
         """ Send a WebSocket pong frame. """
-        buf, h, t = self.encode_hybi(s2b(data), opcode=0x0A, base64=False)
-        self.request.send(buf)
+        self.send_hybi(s2b(data), opcode=0x0A)
 
     def send_ping(self, data=''):
         """ Send a WebSocket ping frame. """
-        buf, h, t = self.encode_hybi(s2b(data), opcode=0x09, base64=False)
-        self.request.send(buf)
+        self.send_hybi(s2b(data), opcode=0x09)
 
     def do_websocket_handshake(self):
         h = self.headers

--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -137,7 +137,6 @@ Traffic Legend:
         Proxy client WebSocket to normal target socket.
         """
         cqueue = []
-        c_pend = 0
         tqueue = []
         rlist = [self.request, target]
 
@@ -157,7 +156,7 @@ Traffic Legend:
                     self.send_ping()
 
             if tqueue: wlist.append(target)
-            if cqueue or c_pend: wlist.append(self.request)
+            if cqueue: wlist.append(self.request)
             try:
                 ins, outs, excepts = select.select(rlist, wlist, [], 1)
             except (select.error, OSError):
@@ -176,7 +175,7 @@ Traffic Legend:
 
             if self.request in outs:
                 # Send queued target data to the client
-                c_pend = self.send_frames(cqueue)
+                self.send_frames(cqueue)
 
                 cqueue = []
 

--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -228,6 +228,8 @@ class WebSocketProxy(websocket.WebSocketServer):
 
     def __init__(self, RequestHandlerClass=ProxyRequestHandler, *args, **kwargs):
         # Save off proxy specific options
+        if sys.platform.startswith("win"):
+            kwargs.pop("multiprocessing_fork", None)
         self.target_host    = kwargs.pop('target_host', None)
         self.target_port    = kwargs.pop('target_port', None)
         self.wrap_cmd       = kwargs.pop('wrap_cmd', None)


### PR DESCRIPTION
Main benefits:
- the functions can be re-used and tested more easily
- it is possible to send the data without first concatenating the header and data together, which can make quite a bit of difference for performance - but note that this depends on a number of factors: size of the payload, memory pressure, network speed, naggle enabled or not, etc.. 
  The threshold is set arbitrarily at 4KB, you could turn it into a constant and if this is set high enough you would not see any difference with the current version of the code, except it will perform better with large packets.
