### PR TITLE
Disable SSL3 in Python wrap_socket

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -833,11 +833,12 @@ class WebSocketServer(object):
                                   % self.cert)
             retsock = None
             try:
-                retsock = ssl.wrap_socket(
-                        sock,
-                        server_side=True,
-                        certfile=self.cert,
-                        keyfile=self.key)
+                # This stuff only works in Python3. In the Python 2.7.4 in Ubuntu it's mighty hard to disable SSLv3, because of the lack of SSLContext
+                sslcontext = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23) # SSLv23 is the deprecrated, python 3.4 compatible way of saying 'everything, also TLS'
+                sslcontext.load_cert_chain(certfile=self.cert, keyfile=self.key);
+                sslcontext.options |= ssl.OP_NO_SSLv3
+
+                retsock = sslcontext.wrap_socket(sock, server_side=True);
             except ssl.SSLError:
                 _, x, _ = sys.exc_info()
                 if x.args[0] == ssl.SSL_ERROR_EOF:


### PR DESCRIPTION
Against POODLE security vulnerability.

Note: breaks Python2 support. Websockify runs fine in Python3, which is even available on Ubuntu 12.04, so support for Python2 should probably be dropped.