### PR TITLE
test_websockifyserver: add send_error stub (for python3.6)

### DIFF
--- a/tests/test_websockifyserver.py
+++ b/tests/test_websockifyserver.py
@@ -80,6 +80,12 @@ class WebSockifyRequestHandlerTestCase(unittest.TestCase):
         self.stubs.Set(BaseHTTPRequestHandler, 'send_response',
                        lambda *args, **kwargs: None)
 
+        def fake_send_error(self, code, message=None, explain=None):
+            self.last_code = code
+
+        self.stubs.Set(BaseHTTPRequestHandler, 'send_error',
+                       fake_send_error)
+
     def tearDown(self):
         """Called automatically after each test."""
         self.stubs.UnsetAll()


### PR DESCRIPTION
test_websockifyserver: add FakeSocket.sendall method

The socket.sendall method is called indirectly via calls
to the python3.6 BaseHTTPRequestHandler.send_error method
which is called by both the Web*RequestHandler classes as
shown below:
```
======================================================================
ERROR: test_list_dir_with_file_only_returns_error (test_websockifyserver.WebSockifyRequestHandlerTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_websockifyserver.py", line 115, in test_list_dir_with_file_only_returns_error
    FakeSocket('GET / HTTP/1.1'), '127.0.0.1', server)
  File "websockify/websockifyserver.py", line 94, in __init__
    WebSocketRequestHandler.__init__(self, req, addr, server)
  File "websockify/websocketserver.py", line 34, in __init__
    BaseHTTPRequestHandler.__init__(self, request, client_address, server)
  File "/usr/lib64/python3.6/socketserver.py", line 696, in __init__
    self.handle()
  File "websockify/websockifyserver.py", line 293, in handle
    SimpleHTTPRequestHandler.handle(self)
  File "/usr/lib64/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "websockify/websocketserver.py", line 46, in handle_one_request
    BaseHTTPRequestHandler.handle_one_request(self)
  File "/usr/lib64/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "websockify/websocketserver.py", line 58, in _websocket_do_GET
    self.do_GET()
  File "websockify/websockifyserver.py", line 259, in do_GET
    SimpleHTTPRequestHandler.do_GET(self)
  File "/usr/lib64/python3.6/http/server.py", line 636, in do_GET
    f = self.send_head()
  File "/usr/lib64/python3.6/http/server.py", line 679, in send_head
    return self.list_directory(path)
  File "websockify/websockifyserver.py", line 263, in list_directory
    self.send_error(404, "No such file")
  File "/usr/lib64/python3.6/http/server.py", line 470, in send_error
    self.end_headers()
  File "/usr/lib64/python3.6/http/server.py", line 520, in end_headers
    self.flush_headers()
  File "/usr/lib64/python3.6/http/server.py", line 524, in flush_headers
    self.wfile.write(b"".join(self._headers_buffer))
  File "/usr/lib64/python3.6/socketserver.py", line 775, in write
    self._sock.sendall(b)
AttributeError: 'FakeSocket' object has no attribute 'sendall'

======================================================================
ERROR: test_normal_get_with_only_upgrade_returns_error (test_websockifyserver.WebSockifyRequestHandlerTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_websockifyserver.py", line 101, in test_normal_get_with_only_upgrade_returns_error
    FakeSocket('GET /tmp.txt HTTP/1.1'), '127.0.0.1', server)
  File "websockify/websockifyserver.py", line 94, in __init__
    WebSocketRequestHandler.__init__(self, req, addr, server)
  File "websockify/websocketserver.py", line 34, in __init__
    BaseHTTPRequestHandler.__init__(self, request, client_address, server)
  File "/usr/lib64/python3.6/socketserver.py", line 696, in __init__
    self.handle()
  File "websockify/websockifyserver.py", line 293, in handle
    SimpleHTTPRequestHandler.handle(self)
  File "/usr/lib64/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "websockify/websocketserver.py", line 46, in handle_one_request
    BaseHTTPRequestHandler.handle_one_request(self)
  File "/usr/lib64/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "websockify/websocketserver.py", line 58, in _websocket_do_GET
    self.do_GET()
  File "websockify/websockifyserver.py", line 257, in do_GET
    self.send_error(405, "Method Not Allowed")
  File "/usr/lib64/python3.6/http/server.py", line 470, in send_error
    self.end_headers()
  File "/usr/lib64/python3.6/http/server.py", line 520, in end_headers
    self.flush_headers()
  File "/usr/lib64/python3.6/http/server.py", line 524, in flush_headers
    self.wfile.write(b"".join(self._headers_buffer))
  File "/usr/lib64/python3.6/socketserver.py", line 775, in write
    self._sock.sendall(b)
AttributeError: 'FakeSocket' object has no attribute 'sendall'
```