### PR TITLE
Fix websockify.js bug caused by upgrade to ws version 3

### DIFF
--- a/other/js/websockify.js
+++ b/other/js/websockify.js
@@ -28,7 +28,7 @@ var argv = require('optimist').argv,
 // Handle new WebSocket client
 new_client = function(client, req) {
     var clientAddr = client._socket.remoteAddress, log;
-    console.log(req.url);
+    console.log(req ? req.url : client.upgradeReq.url);
     log = function (msg) {
         console.log(' ' + clientAddr + ': '+ msg);
     };

--- a/other/js/websockify.js
+++ b/other/js/websockify.js
@@ -26,9 +26,9 @@ var argv = require('optimist').argv,
 
 
 // Handle new WebSocket client
-new_client = function(client) {
+new_client = function(client, req) {
     var clientAddr = client._socket.remoteAddress, log;
-    console.log(client.upgradeReq.url);
+    console.log(req.url);
     log = function (msg) {
         console.log(' ' + clientAddr + ': '+ msg);
     };
@@ -92,7 +92,7 @@ http_request = function (request, response) {
 
     var uri = url.parse(request.url).pathname
         , filename = path.join(argv.web, uri);
-    
+
     fs.exists(filename, function(exists) {
         if(!exists) {
             return http_error(response, 404, "404 Not Found");


### PR DESCRIPTION
Fix for https://github.com/novnc/websockify/issues/280

Fixes error in websockify.js caused by upgrade to version 3 of the `ws` module, which contains breaking changes. See also: https://github.com/websockets/ws/pull/1104