### PR TITLE
Add authentication plugin capabilities to node version of websockify (v2)

### DIFF
--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -10,9 +10,20 @@
  */
 
 const querystring = require('querystring');
-fs = require('fs');
+const fs = require('fs');
 
 function urlTokenMatch(url, token, verbose=false) {
+    /**
+     * Parse the url path, extract the `token` querystring value, and check if
+     * it matches the token argument. If verbose is set to true, log messages
+     * are enabled.
+     *
+     * Args:
+     *      url (string): the path section of the URL
+     *      token (string): the token which the token provided in the URL should
+     *          match
+     *      verbose (boolean): If True, extra console.log messages will be output
+     */
     let splitUrl = url.split("?")
     if (splitUrl.length !== 2) {
         if (verbose) {
@@ -34,6 +45,11 @@ function urlTokenMatch(url, token, verbose=false) {
 }
 
 exports.tokenAuth = function tokenAuth(source) {
+    /**
+     * Authorisation plugin which validates the token query parameter against
+     * a token provided as the argument to the --auth-source command line
+     * argument
+     */
     return function(info) {
         let token = source;
         return urlTokenMatch(info.req.url, token, true);
@@ -41,6 +57,12 @@ exports.tokenAuth = function tokenAuth(source) {
 }
 
 exports.tokenAuthEnv = function tokenAuthEnv(source) {
+    /**
+     * Authorisation plugin which validates the token query parameter against
+     * a token which is the value of an environment variable. The name of this
+     * environment variable is specified as the argument to the command line
+     * argument --auth-source
+     */
     return function(info) {
         let token = process.env[source];
         return urlTokenMatch(info.req.url, token, true);
@@ -48,6 +70,11 @@ exports.tokenAuthEnv = function tokenAuthEnv(source) {
 }
 
 exports.tokenAuthFile = function tokenEnvFile(source) {
+    /**
+     * Authorisation plugin which validates the token query parameter against a
+     * token which is contained in a text file, the path to which is specified
+     * as the value of the --auth-source command line argument
+     */
     return function(info, cb) {
         fs.readFile(source, 'utf8', function(err, data) {
             if (err) {

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -47,8 +47,8 @@ function urlTokenMatch(url, token, verbose=false) {
 exports.tokenAuth = function tokenAuth(source) {
     /**
      * Authorisation plugin which validates the token query parameter against
-     * a token provided as the argument to the --auth-source command line
-     * argument
+     * a token provided as the argument to the `--auth-source` command line
+     * argument.
      */
     return function(info) {
         let token = source;
@@ -61,7 +61,7 @@ exports.tokenAuthEnv = function tokenAuthEnv(source) {
      * Authorisation plugin which validates the token query parameter against
      * a token which is the value of an environment variable. The name of this
      * environment variable is specified as the argument to the command line
-     * argument --auth-source
+     * argument `--auth-source`
      */
     return function(info) {
         let token = process.env[source];
@@ -73,7 +73,7 @@ exports.tokenAuthFile = function tokenEnvFile(source) {
     /**
      * Authorisation plugin which validates the token query parameter against a
      * token which is contained in a text file, the path to which is specified
-     * as the value of the --auth-source command line argument
+     * as the value of the `--auth-source` command line argument
      */
     return function(info, cb) {
         fs.readFile(source, 'utf8', function(err, data) {

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -1,0 +1,27 @@
+/*
+ * An auth plugin must be a function which returns a function conforing to the
+ * requirements of the `verifyClients` option on ws.WebSocket.Server.
+ *
+ * See: https://github.com/websockets/ws/blob/master/doc/ws.md
+ *
+ * If websockify is provided with an --auth-source argument, this will be
+ * passed to the auth plugin as its first argument.
+ *
+ */
+
+const querystring = require('querystring');
+
+exports.tokenAuth = function tokenAuth(source) {
+    return function(info) {
+        console.log(info.req.url);
+        let splitUrl = info.req.url.split("?")
+        if (splitUrl.length !== 2) {
+            return false;
+        }
+        let qs = splitUrl[1];
+        let qs_parsed = querystring.parse(qs)
+        console.log(qs_parsed)
+        return (qs_parsed.token === source);
+    }
+}
+

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -1,5 +1,5 @@
 /*
- * An auth plugin must be a function which returns a function conforing to the
+ * An auth plugin must be a function which returns a function conforming to the
  * requirements of the `verifyClients` option on ws.WebSocket.Server.
  *
  * See: https://github.com/websockets/ws/blob/master/doc/ws.md

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -9,101 +9,78 @@
  *
  */
 
-const querystring = require('querystring');
 const fs = require('fs');
 
-function urlTokenMatch(url, token, verbose=false) {
-    /**
-     * Parse the url path, extract the `token` querystring value, and check if
-     * it matches the token argument. If verbose is set to true, log messages
-     * are enabled.
-     *
-     * Args:
-     *      url (string): the path section of the URL
-     *      token (string): the token which the token provided in the URL should
-     *          match
-     *      verbose (boolean): If True, extra console.log messages will be output
-     */
-    let splitUrl = url.split("?")
-    if (splitUrl.length !== 2) {
-        if (verbose) {
-            console.log("Permission denied. No token provided.");
-        }
-        return false;
-    }
-    let qs = splitUrl[1];
-    let qs_parsed = querystring.parse(qs);
-    let success = (qs_parsed.token === token);
-    if (verbose) {
-        if (!success) {
-            console.log("Permission denied for token: " + qs_parsed.token);
-        } else {
-            console.log("Permission granted for token: " + qs_parsed.token);
-        }
-    }
-    return success;
-}
-
-exports.tokenAuth = function tokenAuth(source) {
-    /**
-     * Authorisation plugin which validates the token query parameter against
-     * a token provided as the argument to the `--auth-source` command line
-     * argument.
-     */
-    return {
-        authenticate(info) {
-            const token = source;
-            return urlTokenMatch(info.req.url, token, true);
-        }
-    }
-}
-
-exports.TokenAuthClass = class TokenAuthClass {
-    /**
-     * Class-based equivalent of tokenAuth
-     */
+class BaseAuth {
 
     constructor(source) {
         this.source = source;
     }
 
     authenticate(info) {
-        const token = this.source;
-        console.log(token)
-        return urlTokenMatch(info.req.url, token, true);
+        return false;
     }
 
 }
 
-exports.tokenAuthEnv = function tokenAuthEnv(source) {
-    /**
-     * Authorisation plugin which validates the token query parameter against
-     * a token which is the value of an environment variable. The name of this
-     * environment variable is specified as the argument to the command line
-     * argument `--auth-source`
-     */
-    return function(info) {
-        let token = process.env[source];
-        return urlTokenMatch(info.req.url, token, true);
+/**
+ * Authorisation plugin which validates origin of the request against a single
+ * permitted origin
+ */
+exports.AuthByOrigin = class AuthByOrigin extends BaseAuth {
+
+    authenticate(info) {
+        const expected = this.source;
+        const actual = info.origin;
+        const allow = expected === actual;
+        if (!allow) {
+            console.log("Denied access from origin: " + actual)
+        }
+        return allow;
     }
+
 }
 
-exports.tokenAuthFile = function tokenEnvFile(source) {
-    /**
-     * Authorisation plugin which validates the token query parameter against a
-     * token which is contained in a text file, the path to which is specified
-     * as the value of the `--auth-source` command line argument
-     */
-    return function(info, cb) {
-        fs.readFile(source, 'utf8', function(err, data) {
+/**
+ * Function-based version of AuthByOrigin
+ */
+exports.AuthByOriginFunctional = function(source) {
+    return {
+        authenticate(info) {
+            const expected = source;
+            const actual = info.origin;
+            const success = expected === actual;
+            if (!success) {
+                console.log("Denied access from origin: " + actual)
+            }
+            return success;
+        }
+    };
+}
+
+/**
+ * Authorisation plugin which validates the origin of the request against
+ * an origin contained in a text file, the path to which is specified
+ * as the value of the `--auth-source` command line argument
+ */
+exports.AuthByOriginFile = class AuthByOriginFile extends BaseAuth {
+
+
+    authenticate(info, cb) {
+        fs.readFile(this.source, 'utf8', function(err, data) {
             if (err) {
                 console.log(err);
                 cb(false);
             } else {
-                let token = data.trim();
-                let success = urlTokenMatch(info.req.url, token, true);
+                const expected = data.trim();
+                const actual = info.origin;
+                const success = expected === actual;
+                if (!success) {
+                    console.log("Denied access from origin: " + actual);
+                }
                 cb(success);
             }
-        });
+        })
     }
+
 }

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -15,7 +15,10 @@ fs = require('fs');
 function urlTokenMatch(url, token, verbose=false) {
     let splitUrl = url.split("?")
     if (splitUrl.length !== 2) {
-        return ["", false];
+        if (verbose) {
+            console.log("Permission denied. No token provided.");
+        }
+        return false;
     }
     let qs = splitUrl[1];
     let qs_parsed = querystring.parse(qs);

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -10,6 +10,7 @@
  */
 
 const querystring = require('querystring');
+fs = require('fs');
 
 function urlTokenMatch(url, token, verbose=false) {
     let splitUrl = url.split("?")
@@ -40,5 +41,20 @@ exports.tokenAuthEnv = function tokenAuthEnv(source) {
     return function(info) {
         let token = process.env[source];
         return urlTokenMatch(info.req.url, token, true);
+    }
+}
+
+exports.tokenAuthFile = function tokenEnvFile(source) {
+    return function(info, cb) {
+        fs.readFile(source, 'utf8', function(err, data) {
+            if (err) {
+                console.log(err);
+                cb(false);
+            } else {
+                let token = data.trim();
+                let success = urlTokenMatch(info.req.url, token, true);
+                cb(success);
+            }
+        });
     }
 }

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -11,17 +11,34 @@
 
 const querystring = require('querystring');
 
+function urlTokenMatch(url, token, verbose=false) {
+    let splitUrl = url.split("?")
+    if (splitUrl.length !== 2) {
+        return ["", false];
+    }
+    let qs = splitUrl[1];
+    let qs_parsed = querystring.parse(qs);
+    let success = (qs_parsed.token === token);
+    if (verbose) {
+        if (!success) {
+            console.log("Permission denied for token: " + qs_parsed.token);
+        } else {
+            console.log("Permission granted for token: " + qs_parsed.token);
+        }
+    }
+    return success;
+}
+
 exports.tokenAuth = function tokenAuth(source) {
     return function(info) {
-        console.log(info.req.url);
-        let splitUrl = info.req.url.split("?")
-        if (splitUrl.length !== 2) {
-            return false;
-        }
-        let qs = splitUrl[1];
-        let qs_parsed = querystring.parse(qs)
-        console.log(qs_parsed)
-        return (qs_parsed.token === source);
+        let token = source;
+        return urlTokenMatch(info.req.url, token, true);
     }
 }
 
+exports.tokenAuthEnv = function tokenAuthEnv(source) {
+    return function(info) {
+        let token = process.env[source];
+        return urlTokenMatch(info.req.url, token, true);
+    }
+}

--- a/other/js/auth_plugin_examples.js
+++ b/other/js/auth_plugin_examples.js
@@ -50,10 +50,29 @@ exports.tokenAuth = function tokenAuth(source) {
      * a token provided as the argument to the `--auth-source` command line
      * argument.
      */
-    return function(info) {
-        let token = source;
+    return {
+        authenticate(info) {
+            const token = source;
+            return urlTokenMatch(info.req.url, token, true);
+        }
+    }
+}
+
+exports.TokenAuthClass = class TokenAuthClass {
+    /**
+     * Class-based equivalent of tokenAuth
+     */
+
+    constructor(source) {
+        this.source = source;
+    }
+
+    authenticate(info) {
+        const token = this.source;
+        console.log(token)
         return urlTokenMatch(info.req.url, token, true);
     }
+
 }
 
 exports.tokenAuthEnv = function tokenAuthEnv(source) {

--- a/other/js/package.json
+++ b/other/js/package.json
@@ -8,7 +8,10 @@
     "type": "git",
     "url": "git://github.com/kanaka/websockify.git"
   },
-  "files": ["../../docs/LICENSE.LGPL-3","websockify.js"],
+  "files": [
+    "../../docs/LICENSE.LGPL-3",
+    "websockify.js"
+  ],
   "bin": {
     "websockify": "./websockify.js"
   },

--- a/other/js/password.txt
+++ b/other/js/password.txt
@@ -1,0 +1,1 @@
+passpass12

--- a/other/js/password.txt
+++ b/other/js/password.txt
@@ -1,1 +1,0 @@
-passpass12

--- a/other/js/utils.js
+++ b/other/js/utils.js
@@ -10,6 +10,14 @@
  * @param  {function} function_or_class
  */
 exports.factorify = function factorify(function_or_class) {
+    // Must be callable
+    if (typeof function_or_class !== "function") {
+        console.log(function_or_class)
+        throw new TypeError(
+            "must be called with a function or class constructor"
+        );
+    }
+
     return (...args) => {
         try {
             return function_or_class(...args);

--- a/other/js/utils.js
+++ b/other/js/utils.js
@@ -1,0 +1,24 @@
+
+/**
+ * A decorator that will wrap a function or a class. In the case of a non-class
+ * function, the wrapped function will behave exactly the same as before.
+ * In the case of a class, the wrapper will allow instantiating the function]
+ * without using the |new| keyword. This is useful when you don't know
+ * ahead of time if the function you will be calling is a class or a non-class
+ * function
+ *
+ * @param  {function} function_or_class
+ */
+exports.factorify = function factorify(function_or_class) {
+    return (...args) => {
+        try {
+            return function_or_class(...args);
+        } catch (e) {
+            if (e instanceof TypeError) {
+                return new function_or_class(...args);
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/other/js/websockify.js
+++ b/other/js/websockify.js
@@ -9,20 +9,20 @@
 //     npm install ws optimist
 
 
-var argv = require('optimist').argv,
-    net = require('net'),
-    http = require('http'),
-    https = require('https'),
-    url = require('url'),
-    path = require('path'),
-    fs = require('fs'),
+const argv = require('optimist').argv,
+      net = require('net'),
+      http = require('http'),
+      https = require('https'),
+      url = require('url'),
+      path = require('path'),
+      fs = require('fs'),
 
-    Buffer = require('buffer').Buffer,
-    WebSocketServer = require('ws').Server,
+      Buffer = require('buffer').Buffer,
+      WebSocketServer = require('ws').Server,
 
-    utils = require('./utils'),
+      utils = require('./utils');
 
-    webServer, wsServer,
+let webServer, wsServer,
     source_host, source_port, target_host, target_port,
     auth_plugin, websocket_server_opts,
     web_path = null;
@@ -30,15 +30,18 @@ var argv = require('optimist').argv,
 
 // Handle new WebSocket client
 const new_client = function(client, req) {
-    var clientAddr = client._socket.remoteAddress, log;
+
     console.log(req ? req.url : client.upgradeReq.url);
-    log = function (msg) {
+
+    const clientAddr = client._socket.remoteAddress;
+    const log = function (msg) {
         console.log(' ' + clientAddr + ': '+ msg);
     };
+
     log('WebSocket connection');
     log('Version ' + client.protocolVersion + ', subprotocol: ' + client.protocol);
 
-    var target = net.createConnection(target_port,target_host, function() {
+    const target = net.createConnection(target_port,target_host, function() {
         log('connected to target');
     });
     target.on('data', function(data) {
@@ -119,10 +122,10 @@ const http_request = function (request, response) {
 
 // parse source and target arguments into parts
 try {
-    source_arg = argv._[0].toString();
-    target_arg = argv._[1].toString();
+    const source_arg = argv._[0].toString();
+    const target_arg = argv._[1].toString();
 
-    var idx;
+    let idx;
     idx = source_arg.indexOf(":");
     if (idx >= 0) {
         source_host = source_arg.slice(0, idx);

--- a/other/js/websockify.js
+++ b/other/js/websockify.js
@@ -29,7 +29,7 @@ var argv = require('optimist').argv,
 
 
 // Handle new WebSocket client
-new_client = function(client, req) {
+const new_client = function(client, req) {
     var clientAddr = client._socket.remoteAddress, log;
     console.log(req ? req.url : client.upgradeReq.url);
     log = function (msg) {
@@ -76,7 +76,7 @@ new_client = function(client, req) {
 
 
 // Send an HTTP error response
-http_error = function (response, code, msg) {
+const http_error = function (response, code, msg) {
     response.writeHead(code, {"Content-Type": "text/plain"});
     response.write(msg + "\n");
     response.end();
@@ -84,7 +84,7 @@ http_error = function (response, code, msg) {
 }
 
 // Process an HTTP static file request
-http_request = function (request, response) {
+const http_request = function (request, response) {
 //    console.log("pathname: " + url.parse(req.url).pathname);
 //    res.writeHead(200, {'Content-Type': 'text/plain'});
 //    res.end('okay');
@@ -183,7 +183,7 @@ if (argv["auth-plugin"]) {
 
     const auth_source = argv["auth-source"] || undefined;
 
-    const auth_plugin = plugin_factory(auth_source);
+    auth_plugin = plugin_factory(auth_source);
 
     websocket_server_opts = {
         server: webServer,

--- a/other/js/websockify.js
+++ b/other/js/websockify.js
@@ -31,7 +31,7 @@ var argv = require('optimist').argv,
 // Handle new WebSocket client
 new_client = function(client, req) {
     var clientAddr = client._socket.remoteAddress, log;
-    console.log(req ? req.url : client.req.url);
+    console.log(req ? req.url : client.upgradeReq.url);
     log = function (msg) {
         console.log(' ' + clientAddr + ': '+ msg);
     };

--- a/other/js/websockify.js
+++ b/other/js/websockify.js
@@ -29,9 +29,9 @@ var argv = require('optimist').argv,
 
 
 // Handle new WebSocket client
-new_client = function(client, upgradeReq) {
+new_client = function(client, req) {
     var clientAddr = client._socket.remoteAddress, log;
-    console.log(upgradeReq ? upgradeReq.url : client.upgradeReq.url);
+    console.log(req ? req.url : client.req.url);
     log = function (msg) {
         console.log(' ' + clientAddr + ': '+ msg);
     };


### PR DESCRIPTION
Duplicate of pull request https://github.com/novnc/websockify/pull/282 , but without the unwanted merge commits.

------------------------------------------------

I have adapted the node.js version of Websockify, to take advantage of the `ws` library's authorization capabilities. Authorisation plugins can now be specified using the `--auth-plugin` and `--auth-source` command line arguments. `--auth-plugin` specifies the `<module>.<member>` function to use as an auth plugin. `--auth-source` provides additional configuration as a string, which is passed as the first argument to the plugin function. This command line interface mirrors that in the Python version of websockify.

Authorisation plugins are functions that take a `source` argument, and return a function that can be used as the `verifyClient` option to the `ws.WebSocket.Server` class from https://github.com/websockets/ws.

The following abridged extract from the `ws` module documentation at https://github.com/websockets/ws/blob/master/doc/ws.md should clarify:

> 
> ### new WebSocket.Server(options[, callback])
> 
> - `options` {Object}
>   ...
>   - `verifyClient` {Function} A function which can be used to validate incoming
>     connections. See description below.
>
>   ...
> - `callback` {Function}
> 
> Create a new server instance. One of `port`, `server` or `noServer` must be
> provided or an error is thrown.
> 
> 
> If `verifyClient` is not set then the handshake is automatically accepted. If
> it is is provided with a single argument then that is:
> 
> - `info` {Object}
>   - `origin` {String} The value in the Origin header indicated by the client.
>   - `req` {http.IncomingMessage} The client HTTP GET request.
>   - `secure` {Boolean} `true` if `req.connection.authorized` or
>     `req.connection.encrypted` is set.
> 
> The return value (Boolean) of the function determines whether or not to accept
> the handshake.
> 
> if `verifyClient` is provided with two arguments then those are:
> 
> - `info` {Object} Same as above.
> - `cb` {Function} A callback that must be called by the user upon inspection
>   of the `info` fields. Arguments in this callback are:
>   - `result` {Boolean} Whether or not to accept the handshake.
>   - `code` {Number} When `result` is `false` this field determines the HTTP
>     error status code to be sent to the client.
>   - `name` {String} When `result` is `false` this field determines the HTTP
>     reason phrase.
