### PR TITLE
Send Content-Type headers with static files

### DIFF
--- a/other/js/package.json
+++ b/other/js/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "ws": ">=0.4.27",
     "optimist": "latest",
+    "mime-types" : "latest",
     "policyfile": "latest"
   }
 }

--- a/other/js/websockify.js
+++ b/other/js/websockify.js
@@ -16,6 +16,7 @@ var argv = require('optimist').argv,
     url = require('url'),
     path = require('path'),
     fs = require('fs'),
+    mime = require('mime-types'),
 
     Buffer = require('buffer').Buffer,
     WebSocketServer = require('ws').Server,
@@ -107,7 +108,13 @@ http_request = function (request, response) {
                 return http_error(response, 500, err);
             }
 
-            response.writeHead(200);
+            var headers = {};
+            var contentType = mime.contentType(path.extname(filename));
+            if (contentType !== false) {
+              headers['Content-Type'] = contentType;
+            }
+
+            response.writeHead(200, headers);
             response.write(file, "binary");
             response.end();
         });


### PR DESCRIPTION
Fixes a problem that occurs in Chrome 61 where the following error message appears in the console:

'Failed to load module script: The server responded with a non-JavaScript MIME type of "".
Strict MIME type checking is enforced for module scripts per HTML spec.'