### PR TITLE
Added SSL-certificate-based client authentication.

### DIFF
--- a/docs/websockify.1
+++ b/docs/websockify.1
@@ -89,12 +89,27 @@ Here is an example of using websockify to wrap the vncserver command (which back
 
 `./websockify 5901 --wrap-mode=ignore -- vncserver -geometry 1024x768 :1`
 
-Here is an example of wrapping telnetd (from krb5-telnetd).telnetd exits after the connection closes so the wrap mode is set to respawn the command:
+Here is an example of wrapping telnetd (from krb5-telnetd). telnetd exits after the connection closes so the wrap mode is set to respawn the command:
 
 `sudo ./websockify 2023 --wrap-mode=respawn -- telnetd -debug 2023`
 
 The wstelnet.html page demonstrates a simple WebSockets based telnet client.
 
+.SS Use client certificate verification
+
+This feature requires Python 2.7.9 or newer or Python 3.4 or newer.
+
+The --verify-client option makes the server ask the client for a SSL certificate. Presenting a valid (not expired and trusted by any supplied certificate authority) certificate is required for the client connection. With -auth-plugin=ClientCertCNAuth, the client certificate can be checked against a list of authorised certificate users. Non-encrypted connection attempts always fail during authentication.
+
+Here is an example of a vncsevrer with password-less, certificate-driven authentication:
+
+`./websockify 5901 --cert=fullchain.pem --key=privkey.pem --ssl-only --verify-client --cafile=ca-certificates.crt --auth-plugin=ClientCertCNAuth --auth-source='jane@example.com Joe User9824510' --web=noVNC/ --wrap-mode=ignore -- vncserver :1 -geometry 1024x768 -SecurityTypes=None`
+
+The --auth-source option takes a white-space separated list of common names. Depending on your clients certificates they can be verified email addresses, user-names or any other string used for identification.
+
+The --cafile option selects a file containing concatenated certificates of authorities trusted for validating clients. If this option is omitted, system default list of CAs is used. Upon connect, the client should supply the whole certificate chain. If your clients are known not to send intermediate certificates, they can be appended to the ca-file as well.
+            
+Note: Most browsers ask the user to select a certificate only while connecting via HTTPS, not WebSockets. Connecting directly to the SSL secured WebSocket may cause the browser to abort the connection. If you want to connect via noVNC, the --web option should point to a copy of noVNC, so it is loaded from the same host.
 
 .SH AUTHOR
 Joel Martin (github@martintribe.org)

--- a/websockify/auth_plugins.py
+++ b/websockify/auth_plugins.py
@@ -81,3 +81,23 @@ class ExpectOrigin(object):
         origin = headers.get('Origin', None)
         if origin is None or origin not in self.source:
             raise InvalidOriginError(expected=self.source, actual=origin)
+            
+class ClientCertCNAuth(object):
+    """Verifies client by SSL certificate. Specify src as whitespace separated list of common names."""
+
+    def __init__(self, src=None):
+        if src is None:
+            self.source = []
+        else:
+            self.source = src.split()
+
+    def authenticate(self, headers, target_host, target_port):
+        try:
+            if (headers.get('SSL_CLIENT_S_DN_CN') not in self.source):
+                raise AuthenticationError(response_code=403)
+        except AuthenticationError:
+            # re-raise AuthenticationError (raised by common name not in configured source list)
+            raise
+        except:
+            # deny access in case any error occurs (i.e. no data provided)
+            raise AuthenticationError(response_code=403)

--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -319,6 +319,7 @@ class WebSockifyServer(object):
     def __init__(self, RequestHandlerClass, listen_fd=None,
             listen_host='', listen_port=None, source_is_ipv6=False,
             verbose=False, cert='', key='', ssl_only=None,
+            verify_client=False, cafile=None,
             daemon=False, record='', web='',
             file_only=False,
             run_once=False, timeout=0, idle_timeout=0, traffic=False,
@@ -333,6 +334,7 @@ class WebSockifyServer(object):
         self.listen_port    = listen_port
         self.prefer_ipv6    = source_is_ipv6
         self.ssl_only       = ssl_only
+        self.verify_client  = verify_client
         self.daemon         = daemon
         self.run_once       = run_once
         self.timeout        = timeout
@@ -352,13 +354,15 @@ class WebSockifyServer(object):
 
         # Make paths settings absolute
         self.cert = os.path.abspath(cert)
-        self.key = self.web = self.record = ''
+        self.key = self.web = self.record = self.cafile = ''
         if key:
             self.key = os.path.abspath(key)
         if web:
             self.web = os.path.abspath(web)
         if record:
             self.record = os.path.abspath(record)
+        if cafile:
+            self.cafile = os.path.abspath(cafile)
 
         if self.web:
             os.chdir(self.web)
@@ -518,7 +522,6 @@ class WebSockifyServer(object):
         """
         ready = select.select([sock], [], [], 3)[0]
 
-
         if not ready:
             raise self.EClose("ignoring socket not ready")
         # Peek, but do not read the data so that we have a opportunity
@@ -538,11 +541,29 @@ class WebSockifyServer(object):
                                   % self.cert)
             retsock = None
             try:
-                retsock = ssl.wrap_socket(
-                        sock,
-                        server_side=True,
-                        certfile=self.cert,
-                        keyfile=self.key)
+                if (hasattr(ssl, 'create_default_context') 
+                    and callable(ssl.create_default_context)):
+                    # create new-style SSL wrapping for extended features
+                    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+                    context.load_cert_chain(certfile=self.cert, keyfile=self.key)
+                    if self.verify_client:
+                        context.verify_mode = ssl.CERT_REQUIRED
+                        if self.cafile:
+                            context.load_verify_locations(cafile=self.cafile)
+                        else:
+                            context.set_default_verify_paths()
+                    retsock = context.wrap_socket(
+                            sock,
+                            server_side=True)
+                else:
+                    if self.verify_client:
+                        raise self.EClose("Client certificate verification requested, but this Python is too old.")
+                    # new-style SSL wrapping is not needed, using to old style
+                    retsock = ssl.wrap_socket(
+                            sock,
+                            server_side=True,
+                            certfile=self.cert,
+                            keyfile=self.key)
             except ssl.SSLError:
                 _, x, _ = sys.exc_info()
                 if x.args[0] == ssl.SSL_ERROR_EOF:


### PR DESCRIPTION
* Incorporates #190 without breaking compatibility towards old Python versions.
* A new plugin allows authenticating clients by the "common name" defined in their certificate.
* Added manual for certificate-based client authentication, including hints to which Python versions allow client certificate authentication.
* Adjusted test to work with new ssl.create_default_context.
* Incorporates changes as requested by CendioOssman.