### PR TITLE
fixed: ssl call error at function load_cert_chain.

### DIFF
--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -353,9 +353,12 @@ class WebSockifyServer(object):
         self.tcp_keepidle   = tcp_keepidle
         self.tcp_keepintvl  = tcp_keepintvl
 
+        # keyfile path must be None if not specified
+        self.key = None
+
         # Make paths settings absolute
         self.cert = os.path.abspath(cert)
-        self.key = self.web = self.record = self.cafile = ''
+        self.web = self.record = self.cafile = ''
         if key:
             self.key = os.path.abspath(key)
         if web:


### PR DESCRIPTION
       If option '--key' is not specified. 'WebSockifyServer class' will
       inital self.key as empty string. but ssl load_cert_chain function
       will raise error 'no such file' with keyfile param empty string.