### PR TITLE
C websockify: Load entire certificate chain

### DIFF
--- a/other/websocket.c
+++ b/other/websocket.c
@@ -169,8 +169,7 @@ ws_ctx_t *ws_socket_ssl(ws_ctx_t *ctx, int socket, char * certfile, char * keyfi
         fatal(msg);
     }
 
-    if (SSL_CTX_use_certificate_file(ctx->ssl_ctx, certfile,
-                                     SSL_FILETYPE_PEM) <= 0) {
+    if (SSL_CTX_use_certificate_chain_file(ctx->ssl_ctx, certfile) <= 0) {
         sprintf(msg, "Unable to load certificate file %s\n", certfile);
         fatal(msg);
     }


### PR DESCRIPTION
Instead of single certificate in one file it is sometimes customary to
chain multiple certificates into the same file. This is common practice
for CAs like letsencrypt that are providing intermediate certificates.

This patch switches loading of only one certificate to loading whole chain
of certificates.

The effects can be seen with e.g. the following command:

openssl s_client -showcerts -connect websockify-hostname:8080

Before the change the verify fails:

Certificate chain
 0 s:/CN=websockify-hostname
   i:/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3

After the change the verify passes:

Certificate chain
 0 s:/CN=websockify-hostname
   i:/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3
 1 s:/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3
   i:/O=Digital Signature Trust Co./CN=DST Root CA X3