### PR TITLE
C websockify: use openssl base64 encode/decode functions

### DIFF
--- a/other/Makefile
+++ b/other/Makefile
@@ -4,7 +4,7 @@ CFLAGS += -fPIC
 all: $(TARGETS)
 
 websockify: websockify.o websocket.o
-	$(CC) $(LDFLAGS) $^ -lssl -lcrypto -lresolv -o $@
+	$(CC) $(LDFLAGS) $^ -lssl -lcrypto -o $@
 
 websocket.o: websocket.c websocket.h
 websockify.o: websockify.c websocket.h


### PR DESCRIPTION
b64_pton and b64_ntop functions are not portable and cannot be found in
all C library implementations (e.g. uClibc, musl).

Since c-websockify already has explicit dependency to openssl it can be
used to replace b64_pton/ntop with versions that are portable without
introducing too much additional code or dependencies.

Fixes #165