### PR TITLE
C websockify: Fix file descriptor leak

### DIFF
--- a/other/websocket.c
+++ b/other/websocket.c
@@ -861,6 +861,7 @@ void start_server() {
             break;   // Child process exits
         } else {         // parent process
             settings.handler_id += 1;
+            close(csock);
         }
     }
     if (pid == 0) {


### PR DESCRIPTION
After fork() the parent process has a copy of clients file descriptor which
needs to be closed by the parent to prevent a descriptor leak.

Fixes #80