### PR TITLE
handler exception: must be str, not bytes

### DIFF
--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -142,7 +142,7 @@ class WebSockifyRequestHandler(WebSocketRequestHandler, SimpleHTTPRequestHandler
         if bufs:
             for buf in bufs:
                 if self.rec:
-                    self.rec.write("%s,\n" % repr("{%s{" % tdelta + buf))
+                    self.rec.write("{},\n".format("{{{}{}{{".format(tdelta, buf)))
                 self.send_parts.append(buf)
 
         # Flush any previously queued data
@@ -189,7 +189,7 @@ class WebSockifyRequestHandler(WebSocketRequestHandler, SimpleHTTPRequestHandler
             self.print_traffic("}")
 
             if self.rec:
-                self.rec.write("%s,\n" % repr("}%s}" % tdelta + buf))
+                self.rec.write("{},\n".format("}}{}{}}}".format(tdelta, buf)))
 
             bufs.append(buf)
 


### PR DESCRIPTION
Environment: **Python 3.6.4, MacOS 10.13.3 and Ubuntu 14.04.4**

How I can reproduce?
1. use x11vnc, noVNC, websockify(from master branch)
2. run websockify programmatically:
```
    sys.argv = [
        "--daemon",
        "--verbose",
        "--wrap-mode=ignore",
        "--record=/tmp/proxy_vnc_{}.log".format(port),
        "0.0.0.0:50970",
        "192.168.1.102:33305"
    ]
    proxy = multiprocessing.Process(
        target=websockify.websocketproxy.websockify_init,
        name="{}.proxy".format(__name__)
    )

    proxy.start()
```
3. run x11vnc
```
x11vnc -forever -shared -rfbport 33305 --scale 800x600 -nopw -display $DISPLAY
```
4. open noVNC and connect to 0.0.0.0:50970 (got "disconnected" and error in terminal)


```python
WebSocket server settings:
  - Listen on 0.0.0.0:50970
  - No SSL/TLS support (no cert file)
  - Recording to '/tmp/proxy_vnc_50970.log.*'
  - proxying from 0.0.0.0:50970 to 192.168.1.102:33305
127.0.0.1: new handler Process
127.0.0.1 - - [23/Mar/2018 12:03:22] "GET /websockify HTTP/1.1" 101 -
127.0.0.1 - - [23/Mar/2018 12:03:22] 127.0.0.1: Plain non-SSL (ws://) WebSocket connection
127.0.0.1 - - [23/Mar/2018 12:03:22] 127.0.0.1: Path: '/websockify'
127.0.0.1 - - [23/Mar/2018 12:03:22] opening record file: /tmp/proxy_vnc_50970.log.1
127.0.0.1 - - [23/Mar/2018 12:03:22] connecting to: 192.168.1.102:33305
127.0.0.1 - - [23/Mar/2018 12:03:22] 192.168.1.102:33305: Closed target
handler exception: must be str, not bytes
exception
Traceback (most recent call last):
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websockifyserver.py", line 669, in top_new_client
    client = self.do_handshake(startsock, address)
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websockifyserver.py", line 597, in do_handshake
    self.RequestHandlerClass(retsock, address, self)
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websockifyserver.py", line 100, in __init__
    WebSocketRequestHandler.__init__(self, req, addr, server)
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websocketserver.py", line 36, in __init__
    BaseHTTPRequestHandler.__init__(self, request, client_address, server)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/socketserver.py", line 696, in __init__
    self.handle()
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websockifyserver.py", line 300, in handle
    SimpleHTTPRequestHandler.handle(self)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websocketserver.py", line 48, in handle_one_request
    BaseHTTPRequestHandler.handle_one_request(self)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websocketserver.py", line 58, in _websocket_do_GET
    self.handle_upgrade()
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websockifyserver.py", line 217, in handle_upgrade
    WebSocketRequestHandler.handle_upgrade(self)
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websocketserver.py", line 85, in handle_upgrade
    self.handle_websocket()
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websockifyserver.py", line 255, in handle_websocket
    self.new_websocket_client()
  File "/Users/v/.tox/lib/python3.6/site-packages/websockify/websocketproxy.py", line 125, in new_websocket_client
    self.do_proxy(tsock)
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websocketproxy.py", line 202, in do_proxy
    c_pend = self.send_frames(cqueue)
  File "/Users/user/.tox/lib/python3.6/site-packages/websockify/websockifyserver.py", line 145, in send_frames
    self.rec.write("%s,\n" % repr("{%s{" % tdelta + buf))
TypeError: must be str, not bytes
```