### PR TITLE
[Python] Cmd line parameter to log proxied clients

### DIFF
--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -457,6 +457,9 @@ def websockify_init():
     parser.add_option("--log-file", metavar="FILE",
             dest="log_file",
             help="File where logs will be saved")
+    parser.add_option("--log-proxied-client", action="store_true",
+            help="prepends the content of the X-Forwarded-For "
+            "header (if present) to the immediate client's IP in logs")
 
 
     (opts, args) = parser.parse_args()

--- a/websockify/websocketserver.py
+++ b/websockify/websocketserver.py
@@ -17,6 +17,7 @@ except ImportError:
 
 from websockify.websocket import WebSocket, WebSocketWantReadError, WebSocketWantWriteError
 
+
 class WebSocketRequestHandler(BaseHTTPRequestHandler):
     """WebSocket request handler base class.
 
@@ -34,6 +35,13 @@ class WebSocketRequestHandler(BaseHTTPRequestHandler):
 
     def __init__(self, request, client_address, server):
         BaseHTTPRequestHandler.__init__(self, request, client_address, server)
+
+    def address_string(self, show_proxied=False):
+        immediate_client = super(WebSocketRequestHandler, self).address_string()
+        fwd_for = self.headers.get("X-Forwarded-For", None)
+        if show_proxied and fwd_for:
+            return "{},{}".format(fwd_for, immediate_client)
+        return immediate_client
 
     def handle_one_request(self):
         """Extended request handler


### PR DESCRIPTION
When running behind a reverse proxy, websockify doesn't currently read and log anything that could provide information on the originating client.

This code adds a startup flag (`--log-proxied-client`) to enable logging of originating client plus intermediate proxies. Information is retrieved from the "X-Forwarded-For" header (if present). The immediate client would be logged too at the end of the content of the header, separated by a comma.

Eg:
* default message: `127.0.0.1: Token 'abcd' not found`
* using the `--log-proxied-client` option: `192.168.0.51,127.0.0.1: Token 'abcd' not found`

See also https://github.com/novnc/websockify/issues/334