### PR TITLE
README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,11 @@ These are not necessary for the basic operation.
 
 * Token plugins: a single instance of websockify can connect clients to
   multiple different pre-configured targets, depending on the token sent
-  by the client using the `token` URL parameter or the hostname, if you
-  use `--host-token`. This functionality is activated with the
-  `--token-plugin CLASS` and `--token-source ARG` options, where CLASS is
-  usually one from token_plugins.py and ARG is the plugin's configuration.
+  by the client using the `token` URL parameter, or the hostname used to
+  reach websockify, if you use `--host-token`. This functionality is
+  activated with the `--token-plugin CLASS` and `--token-source ARG`
+  options, where CLASS is usually one from token_plugins.py and ARG is
+  the plugin's configuration.
 
 ### Implementations of websockify
 
@@ -173,6 +174,20 @@ client (use 'localhost' and '2023' for the host and port
 respectively).
 
 
+### Installing the Python implementation of websockify
+
+Download one of the releases or the latest development version, extract
+it and run `python setup.py install` as root in the directory where you
+extracted the files. Normally, this will also install numpy for better
+performance, if you don't have it installed already. However, numpy is
+optional. If you don't want to install numpy or if you can't compile it,
+you can edit setup.py and remove the `install_requires=['numpy'],` line
+before running `python setup.py install`.
+
+Afterwards, websockify should be available in your path. Run
+`websockify --help` to confirm it's installed correctly.
+
+
 ### Building the Python ssl module (for python 2.5 and older)
 
 * Install the build dependencies. On Ubuntu use this command:
@@ -193,4 +208,3 @@ respectively).
     `cd ../`
 
     `ln -sf ssl-1.15/build/lib.linux-*/ssl ssl`
-


### PR DESCRIPTION
I've added a section about installing websockify to the README and clarified usage of --host-token. With this change, you could close https://github.com/novnc/websockify/issues/337

I also considered removing the section about building the SSL module for python 2.5, as nobody should be using that, but I think it's best to discuss that change first.