### PR TITLE
Very first step for Windows support

### DIFF
--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -13,9 +13,15 @@ as taken from http://docs.python.org/dev/library/ssl.html#certificates
 
 import signal, socket, optparse, time, os, sys, subprocess, logging, errno, ssl
 try:
-    from socketserver import ForkingMixIn
+    try:
+        from socketserver import ForkingMixIn
+    except ImportError:
+        from socketserver import ThreadingMixIn as ForkingMixIn
 except ImportError:
-    from SocketServer import ForkingMixIn
+    try:
+        from SocketServer import ForkingMixIn
+    except ImportError:
+        from SocketServer import ThreadingMixIn as ForkingMixIn
 
 try:
     from http.server import HTTPServer

--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -14,6 +14,7 @@ as taken from http://docs.python.org/dev/library/ssl.html#certificates
 
 import os, sys, time, errno, signal, socket, select, logging
 import multiprocessing
+import warnings
 
 # Imports that vary by python version
 
@@ -42,7 +43,8 @@ if sys.platform == 'win32':
     import multiprocessing.reduction
     # the multiprocesssing module behaves much differently on Windows,
     # and we have yet to fix all the bugs
-    sys.exit("Windows is not supported at this time")
+    warnings.warn("Windows is not fully supported at this time",
+                  category=RuntimeWarning)
 
 from websockify.websocket import WebSocket, WebSocketWantReadError, WebSocketWantWriteError
 from websockify.websocketserver import WebSocketRequestHandlerMixIn


### PR DESCRIPTION
There were 2 problems (error and restriction) when running the latest websockify (from github) on Windows machine. But it is probably valuable to work around them quickly because websockify+novnc works fine on my Windows machine after applying this change.

**Error**

```
Traceback (most recent call last):
  File "websockify\websocketproxy.py", line 16, in <module>
    from socketserver import ForkingMixIn
ImportError: cannot import name 'ForkingMixIn' from 'socketserver' (C:\Program Files\Python37\lib\socketserver.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "websockify\websocketproxy.py", line 18, in <module>
    from SocketServer import ForkingMixIn
ModuleNotFoundError: No module named 'SocketServer'
```

**Restriction**

```
WARNING: no 'resource' module, daemonizing is disabled
Windows is not supported at this time
```
