### PR TITLE
trap Exception during SimpleHTTPRequestHandler.handle call

### DIFF
--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -315,7 +315,11 @@ class WebSockifyRequestHandler(WebSocketRequestHandlerMixIn, SimpleHTTPRequestHa
         if self.run_once:
             self.handle_one_request()
         else:
-            SimpleHTTPRequestHandler.handle(self)
+            try:
+                SimpleHTTPRequestHandler.handle(self)
+            except Exception:
+                exc = sys.exc_info()[1]
+                self.send_error(400, str(exc))
 
     def log_request(self, code='-', size='-'):
         if self.verbose:


### PR DESCRIPTION
There could be any error during a normal GET operation or even during a
'server-up' check before making an upgrade call. These errors are
currently unhandled, as a result the exception rises to the top of the
stack and if run_once is not used the entire process crashes with an
exception.

This problem become widely visible when using the
WebSocketProxy  which uses a request handler class.
To handle every request a new process is spawned and if it is an invalid
request (empty request, SSL HELLO etc) the process crashes.

With this patch in such a case the request is caught and an error is
sent back, allowing a graceful termination of process.