### PR TITLE
Re-enable Windows support

### DIFF
--- a/run
+++ b/run
@@ -2,4 +2,5 @@
 
 import websockify
 
-websockify.websocketproxy.websockify_init()
+if __name__ == '__main__':
+	websockify.websocketproxy.websockify_init()

--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -13,9 +13,9 @@ as taken from http://docs.python.org/dev/library/ssl.html#certificates
 
 import signal, socket, optparse, time, os, sys, subprocess, logging, errno, ssl
 try:
-    from socketserver import ForkingMixIn
+    from socketserver import ThreadingMixIn
 except ImportError:
-    from SocketServer import ForkingMixIn
+    from SocketServer import ThreadingMixIn
 
 try:
     from http.server import HTTPServer
@@ -726,7 +726,7 @@ def websockify_init():
         server.start_server()
 
 
-class LibProxyServer(ForkingMixIn, HTTPServer):
+class LibProxyServer(ThreadingMixIn, HTTPServer):
     """
     Just like WebSocketProxy, but uses standard Python SocketServer
     framework.

--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -40,9 +40,6 @@ for mod, msg in [('ssl', 'TLS/SSL/wss is disabled'),
 if sys.platform == 'win32':
     # make sockets pickle-able/inheritable
     import multiprocessing.reduction
-    # the multiprocesssing module behaves much differently on Windows,
-    # and we have yet to fix all the bugs
-    sys.exit("Windows is not supported at this time")
 
 from websockify.websocket import WebSocket, WebSocketWantReadError, WebSocketWantWriteError
 from websockify.websocketserver import WebSocketRequestHandlerMixIn


### PR DESCRIPTION
Thanks to the work of @sakurai-youhei, Windows support is now back. It works well enough on Python 3.7. Older versions have not been tested.

Replaces #376 and fixes #67.