### PR TITLE
novnc redis backed token demo

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,5 @@ mox3
 nose
 jwcrypto;python_version>="2.7"
 enum34;python_version=="3.3"
+redis;python_version>="2.7"
+simplejson;python_version>="2.7"

--- a/websockify/auth_plugins.py
+++ b/websockify/auth_plugins.py
@@ -87,7 +87,7 @@ class ExpectOrigin(object):
         origin = headers.get('Origin', None)
         if origin is None or origin not in self.source:
             raise InvalidOriginError(expected=self.source, actual=origin)
-            
+
 class ClientCertCNAuth(object):
     """Verifies client by SSL certificate. Specify src as whitespace separated list of common names."""
 

--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -134,3 +134,23 @@ class JWTTokenApi(BasePlugin):
         except ImportError as e:
             print("package jwcrypto not found, are you sure you've installed it correctly?", file=sys.stderr)
             return None
+
+import sys
+
+if sys.version_info >= (2, 7):
+    import redis
+    import simplejson
+
+    class TokenRedis(object):
+        def __init__(self, src):
+            self._server, self._port = src.split(":")
+
+        def lookup(self, token):
+            client = redis.Redis(host=self._server,port=self._port)
+            stuff = client.get(token)
+            if stuff is None:
+                return None
+            else:
+                combo = simplejson.loads(stuff.decode("utf-8"))
+                pair = combo["host"]
+                return pair.split(':')


### PR DESCRIPTION
This patch is extending the token backend (plugins) with redis in ```websockify/token_plugins.py``` file and then adds a demo for that purpose ```runNoVncWs.sh``` it actually pulls the novnc and patches ```novnc/app/ui.js``` to pass through the token from ```vnc.html?token=token``` to the ```websockify``` WS url.
