### PR TITLE
Add a __main__.py file for invocation as a module

### DIFF
--- a/run
+++ b/run
@@ -1,6 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env sh
 
-import websockify
+BASE_DIR="$(dirname "$(realpath "$0")")"
 
-if __name__ == '__main__':
-	websockify.websocketproxy.websockify_init()
+cd "$BASE_DIR"
+
+python -m websockify $@

--- a/websockify/__main__.py
+++ b/websockify/__main__.py
@@ -1,0 +1,4 @@
+import websockify
+
+if __name__ == '__main__':
+    websockify.websocketproxy.websockify_init()


### PR DESCRIPTION
This file allows an easy invocation of websockify as a module, which is handy when running into shebang issues (like this: https://github.com/pypa/virtualenv/issues/596).
With this patch, `python -m websockify ...` has just the same behavior as `./run ...`.