### PR TITLE
Use Ubuntu Trusty (14.04) for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
     - 2.7
     - 3.3
     - 3.4
+# We need trusty for Python 2.6. We can raise this when we no longer
+# care about 2.6.
+dist: trusty
 
 install:
     - pip install 'setuptools>=18.5,<=39.0.0'


### PR DESCRIPTION
Python 2.6 is not available in the newer environment, so make sure
we're getting the one we need for now.