### PR TITLE
run: Fix shell scripting bugs

### DIFF
--- a/run
+++ b/run
@@ -1,7 +1,4 @@
 #!/usr/bin/env sh
-
-BASE_DIR="$(cd $(dirname "$0"); pwd)"
-
-cd "$BASE_DIR"
-
-python -m websockify $@
+set -e
+cd "$(dirname "$0")"
+exec python -m websockify "$@"


### PR DESCRIPTION
* Use double quotes around `"$@"` to fix invocation with arguments including spaces.
* Use double quotes around `"$(dirname "$0")"` to fix invocation inside a directory path including spaces.
* Use `set -e` to abort in case `cd` fails.
* Use `exec` to avoid forking an unnecessary wrapper process.
* Skip an unnecessary `cd` → `pwd` → `cd` dance, just use `cd`.