### PR TITLE
Coerce BaseTokenAPI port to int if numeric

### DIFF
--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -70,6 +70,9 @@ class BaseTokenAPI(BasePlugin):
     def process_result(self, resp):
         host, port = resp.text.split(':')
         port = port.encode('ascii','ignore')
+        port = str.strip(port)
+        if str.isdigit(port):
+            port = int(port)
         return [ host, port ]
 
     def lookup(self, token):


### PR DESCRIPTION
This pull request builds on b46fab5 to further sanitize the port value that comes in when using the BaseTokenAPI plugin.

As far as I can tell, b46fab5 _only_ supports ascii based port values like `ssh` and not integer-based values like `22`. This results in identical failures to the ones described in novnc/websockify#399:

```
WebSocket server settings:
  - Listen on :80
  - No SSL/TLS support (no cert file)
  - proxying from :80 to targets generated by BaseTokenAPI
172.17.0.1 - - [02/Sep/2019 19:05:25] 172.17.0.1: Plain non-SSL (ws://) WebSocket connection
172.17.0.1 - - [02/Sep/2019 19:05:25] 172.17.0.1: Path: '/websockify?token=8bff5517-f620-461c-82df-6eb42163411b'
172.17.0.1 - - [02/Sep/2019 19:05:25] connecting to: 172.16.16.16:5910

172.17.0.1 - - [02/Sep/2019 19:05:25] Failed to connect to 172.16.16.16:5910
```

This commit makes two changes:
1. Strips any leading or trailing spaces from the port value
2. Checks to see if the ascii-encoded string is composed of digits, and if so, coerce the value to an `int`