### PR TITLE
Remove str decode function from TokenRedis class

### DIFF
--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -154,6 +154,6 @@ class TokenRedis(object):
         if stuff is None:
             return None
         else:
-            combo = simplejson.loads(stuff.decode("utf-8"))
+            combo = simplejson.loads(stuff)
             pair = combo["host"]
             return pair.split(':')


### PR DESCRIPTION
I'm using Python 2 version

![image](https://user-images.githubusercontent.com/13731831/74601142-79351700-50d5-11ea-81c8-4e17eb371d70.png)

if use str decode function, Websockify will be throw an error, the error code 1011.
remove the str decode function,  Websockify can connect the remote desktop.