### PR TITLE
Update test requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: python
 python:
-    - 2.6
     - 2.7
-    - 3.3
-    - 3.4
-# We need trusty for Python 2.6. We can raise this when we no longer
-# care about 2.6.
-dist: trusty
+    - 3.6
 
 install:
     - pip install 'setuptools>=18.5,<=39.0.0'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 mox3
 nose
 jwcrypto;python_version>="2.7"
-enum34;python_version=="3.3"
 redis;python_version>="2.7"
 simplejson;python_version>="2.7"


### PR DESCRIPTION
Travis are dropping older Python environments, so update things to
something that reflects what current distributions are using (e.g. Red
Hat Enterprise Linux 7).