### PR TITLE
Use GitHub's recommended .gitignore file for Python projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@
 target.cfg
 target.cfg.d
 .tox
+
+build/
+dist/
 *.egg-info


### PR DESCRIPTION
Taken from https://github.com/github/gitignore/blob/master/Python.gitignore