### PR TITLE
Require same arguments on insufficient socket space

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -436,6 +436,9 @@ class WebSocket(object):
         WebSocketWantWriteError can be raised if there is insufficient
         space in the underlying socket.
         """
+        if not isinstance(msg, bytes):
+            raise TypeError
+
         if not self._sent_close:
             # Only called to flush?
             self._sendmsg(0x2, msg)
@@ -445,10 +448,16 @@ class WebSocket(object):
 
     def ping(self, data=''.encode('ascii')):
         """Write a ping message to the WebSocket."""
+        if not isinstance(data, bytes):
+            raise TypeError
+
         self._sendmsg(0x9, data)
 
     def pong(self, data=''.encode('ascii')):
         """Write a pong message to the WebSocket."""
+        if not isinstance(data, bytes):
+            raise TypeError
+
         self._sendmsg(0xA, data)
 
     def shutdown(self, how, code=1000, reason=None):

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -421,6 +421,9 @@ class WebSocket(object):
         WebSocketWantWriteError can be raised if there is insufficient
         space in the underlying socket.
         """
+        if len(bytes) == 0:
+            return 0
+
         return self.sendmsg(bytes)
 
     def sendmsg(self, msg):
@@ -435,8 +438,7 @@ class WebSocket(object):
         """
         if not self._sent_close:
             # Only called to flush?
-            if msg:
-                self._sendmsg(0x2, msg)
+            self._sendmsg(0x2, msg)
 
         self._flush()
         return len(msg)

--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -146,20 +146,14 @@ class WebSockifyRequestHandler(WebSocketRequestHandlerMixIn, SimpleHTTPRequestHa
                     self.rec.write("'{{{0}{{{1}',\n".format(tdelta, bufstr))
                 self.send_parts.append(buf)
 
-        # Flush any previously queued data
-        try:
-            self.request.sendmsg('')
-        except WebSocketWantWriteError:
-            return True
-
         while self.send_parts:
             # Send pending frames
-            buf = self.send_parts.pop(0)
             try:
-                self.request.sendmsg(buf)
+                self.request.sendmsg(self.send_parts[0])
             except WebSocketWantWriteError:
                 self.print_traffic("<.")
                 return True
+            self.send_parts.pop()
             self.print_traffic("<")
 
         return False


### PR DESCRIPTION
This matches the behaviour of SSLSocket, which we are trying to mimic. It also closely matches the behaviour of normal Socket which can be assumed to not have sent anything if an error occurs. We might actually
send some data, but the caller cannot really see that and must call us again as if no data was sent.
