### PR TITLE
fixed a bug in the function of send_frames.

### DIFF
--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -149,10 +149,13 @@ class WebSockifyRequestHandler(WebSocketRequestHandlerMixIn, SimpleHTTPRequestHa
         while self.send_parts:
             # Send pending frames
             try:
-                self.request.sendmsg(self.send_parts.pop(0))
+                # send the first frame.
+                self.request.sendmsg(self.send_parts[0])
             except WebSocketWantWriteError:
                 self.print_traffic("<.")
                 return True
+            # pop the first frame. I think `self.send_parts.pop()` is incorrect. because the frame does not sended.
+            self.send_parts.pop(0)
             self.print_traffic("<")
 
         return False

--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -149,11 +149,10 @@ class WebSockifyRequestHandler(WebSocketRequestHandlerMixIn, SimpleHTTPRequestHa
         while self.send_parts:
             # Send pending frames
             try:
-                self.request.sendmsg(self.send_parts[0])
+                self.request.sendmsg(self.send_parts.pop(0))
             except WebSocketWantWriteError:
                 self.print_traffic("<.")
                 return True
-            self.send_parts.pop()
             self.print_traffic("<")
 
         return False


### PR DESCRIPTION
Today, I found a bug when I use the latest noVNC lib. Those are error pictures. When I use the another computer connect to host:port/websockify, it does not work well.
![截图_2020-10-21_16-51-09](https://user-images.githubusercontent.com/41138618/96701801-9720ed00-13c3-11eb-861c-9afc708c05c7.png)
![2](https://user-images.githubusercontent.com/41138618/96701827-9d16ce00-13c3-11eb-9c83-03611a5ebff0.png)
Due to a mouth ago, I had builded a test service. So, I check the code of websockify.
I discovered the $PRO_DIR/websockify/websockifyserver.py has a problem in function of send_frames.
In this part of the function, it send self.send_parts[0], but to pop the self.send_parts[end]. So, I did a small changed for it. Now it works well.