### PR TITLE
Remove Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - 2.7
     - 3.6
 
 install:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 mock
 nose
-jwcrypto;python_version>="2.7"
-redis;python_version>="2.7"
-simplejson;python_version>="2.7"
+jwcrypto
+redis
+simplejson

--- a/tests/test_websocketproxy.py
+++ b/tests/test_websocketproxy.py
@@ -20,32 +20,20 @@ import sys
 import unittest
 import unittest
 import socket
-try:
-    from mock import patch
-except ImportError:
-    from unittest.mock import patch
+from io import StringIO
+from io import BytesIO
+from unittest.mock import patch
+
+from jwcrypto import jwt
 
 from websockify import websocketproxy
 from websockify import token_plugins
 from websockify import auth_plugins
 
-if sys.version_info >= (2,7):
-    from jwcrypto import jwt
-
-try:
-    from StringIO import StringIO
-    BytesIO = StringIO
-except ImportError:
-    from io import StringIO
-    from io import BytesIO
-
 
 class FakeSocket(object):
-    def __init__(self, data=''):
-        if isinstance(data, bytes):
-            self._data = data
-        else:
-            self._data = data.encode('latin_1')
+    def __init__(self, data=b''):
+        self._data = data
 
     def recv(self, amt, flags=None):
         res = self._data[0:amt]
@@ -76,7 +64,7 @@ class ProxyRequestHandlerTestCase(unittest.TestCase):
     def setUp(self):
         super(ProxyRequestHandlerTestCase, self).setUp()
         self.handler = websocketproxy.ProxyRequestHandler(
-            FakeSocket(''), "127.0.0.1", FakeServer())
+            FakeSocket(), "127.0.0.1", FakeServer())
         self.handler.path = "https://localhost:6080/websockify?token=blah"
         self.handler.headers = None
         patch('websockify.websockifyserver.WebSockifyServer.socket').start()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py24,py26,py27,py33,py34
+envlist = py34
 
 [testenv]
 commands = nosetests {posargs}

--- a/websockify/auth_plugins.py
+++ b/websockify/auth_plugins.py
@@ -1,4 +1,4 @@
-class BasePlugin(object):
+class BasePlugin():
     def __init__(self, src=None):
         self.source = src
 
@@ -15,7 +15,7 @@ class AuthenticationError(Exception):
         if log_msg is None:
             log_msg = response_msg
 
-        super(AuthenticationError, self).__init__('%s %s' % (self.code, log_msg))
+        super().__init__('%s %s' % (self.code, log_msg))
 
 
 class InvalidOriginError(AuthenticationError):
@@ -23,13 +23,13 @@ class InvalidOriginError(AuthenticationError):
         self.expected_origin = expected
         self.actual_origin = actual
 
-        super(InvalidOriginError, self).__init__(
+        super().__init__(
             response_msg='Invalid Origin',
             log_msg="Invalid Origin Header: Expected one of "
                     "%s, got '%s'" % (expected, actual))
 
 
-class BasicHTTPAuth(object):
+class BasicHTTPAuth():
     """Verifies Basic Auth headers. Specify src as username:password"""
 
     def __init__(self, src=None):
@@ -76,7 +76,7 @@ class BasicHTTPAuth(object):
         raise AuthenticationError(response_code=401,
                                   response_headers={'WWW-Authenticate': 'Basic realm="Websockify"'})
 
-class ExpectOrigin(object):
+class ExpectOrigin():
     def __init__(self, src=None):
         if src is None:
             self.source = []
@@ -88,7 +88,7 @@ class ExpectOrigin(object):
         if origin is None or origin not in self.source:
             raise InvalidOriginError(expected=self.source, actual=origin)
 
-class ClientCertCNAuth(object):
+class ClientCertCNAuth():
     """Verifies client by SSL certificate. Specify src as whitespace separated list of common names."""
 
     def __init__(self, src=None):

--- a/websockify/sysloghandler.py
+++ b/websockify/sysloghandler.py
@@ -44,7 +44,7 @@ class WebsockifySysLogHandler(handlers.SysLogHandler):
             self._legacy = True
             self._head_fmt = self._legacy_head_fmt
 
-        handlers.SysLogHandler.__init__(self, address, facility, socktype)
+        super().__init__(address, facility, socktype)
 
 
     def emit(self, record):

--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -1,8 +1,7 @@
-from __future__ import print_function
 import os
 import sys
 
-class BasePlugin(object):
+class BasePlugin():
     def __init__(self, src):
         self.source = src
 
@@ -15,7 +14,7 @@ class ReadOnlyTokenFile(BasePlugin):
     #   token: host:port
     # or a directory of such files
     def __init__(self, *args, **kwargs):
-        super(ReadOnlyTokenFile, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._targets = None
 
     def _load_targets(self):
@@ -57,7 +56,7 @@ class TokenFile(ReadOnlyTokenFile):
     def lookup(self, token):
         self._load_targets()
 
-        return super(TokenFile, self).lookup(token)
+        return super().lookup(token)
 
 
 class BaseTokenAPI(BasePlugin):
@@ -137,7 +136,7 @@ class JWTTokenApi(BasePlugin):
             print("package jwcrypto not found, are you sure you've installed it correctly?", file=sys.stderr)
             return None
 
-class TokenRedis(object):
+class TokenRedis():
     def __init__(self, src):
         self._server, self._port = src.split(":")
 
@@ -162,7 +161,7 @@ class TokenRedis(object):
 
 class UnixDomainSocketDirectory(BasePlugin):
     def __init__(self, *args, **kwargs):
-        super(UnixDomainSocketDirectory, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._dir_path = os.path.abspath(self.source)
 
     def lookup(self, token):

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -749,7 +749,7 @@ class WebSocket(object):
                 mask = numpy.frombuffer(mask, dtype, count=1)
                 data = numpy.frombuffer(buf, dtype, count=int(plen / 4))
                 #b = numpy.bitwise_xor(data, mask).data
-                b = numpy.bitwise_xor(data, mask).tostring()
+                b = numpy.bitwise_xor(data, mask).tobytes()
 
             if plen % 4:
                 dtype=numpy.dtype('B')
@@ -758,15 +758,15 @@ class WebSocket(object):
                 mask = numpy.frombuffer(mask, dtype, count=(plen % 4))
                 data = numpy.frombuffer(buf, dtype,
                         offset=plen - (plen % 4), count=(plen % 4))
-                c = numpy.bitwise_xor(data, mask).tostring()
+                c = numpy.bitwise_xor(data, mask).tobytes()
             return b + c
         else:
             # Slower fallback
             data = array.array('B')
-            data.fromstring(buf)
+            data.frombytes(buf)
             for i in range(len(data)):
                 data[i] ^= mask[i % 4]
-            return data.tostring()
+            return data.tobytes()
 
     def _encode_hybi(self, opcode, buf, mask_key=None, fin=True):
         """ Encode a HyBi style WebSocket frame.

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -22,6 +22,7 @@ import ssl
 import struct
 from base64 import b64encode
 from hashlib import sha1
+from urllib.parse import urlparse
 
 try:
     import numpy
@@ -30,25 +31,10 @@ except ImportError:
     warnings.warn("no 'numpy' module, HyBi protocol will be slower")
     numpy = None
 
-# python 3.0 differences
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-
-# SSLWant*Error is 2.7.9+
-try:
-    class WebSocketWantReadError(ssl.SSLWantReadError):
-        pass
-    class WebSocketWantWriteError(ssl.SSLWantWriteError):
-        pass
-except AttributeError:
-    class WebSocketWantReadError(OSError):
-        def __init__(self):
-            OSError.__init__(self, errno.EWOULDBLOCK)
-    class WebSocketWantWriteError(OSError):
-        def __init__(self):
-            OSError.__init__(self, errno.EWOULDBLOCK)
+class WebSocketWantReadError(ssl.SSLWantReadError):
+    pass
+class WebSocketWantWriteError(ssl.SSLWantWriteError):
+    pass
 
 class WebSocket(object):
     """WebSocket protocol socket like class.
@@ -87,11 +73,11 @@ class WebSocket(object):
 
         self._state = "new"
 
-        self._partial_msg = ''.encode("ascii")
+        self._partial_msg = b''
 
-        self._recv_buffer = ''.encode("ascii")
+        self._recv_buffer = b''
         self._recv_queue = []
-        self._send_buffer = ''.encode("ascii")
+        self._send_buffer = b''
 
         self._previous_sendmsg = None
 
@@ -166,9 +152,7 @@ class WebSocket(object):
             self._key = ''
             for i in range(16):
                 self._key += chr(random.randrange(256))
-            if sys.hexversion >= 0x3000000:
-                self._key = bytes(self._key, "latin-1")
-            self._key = b64encode(self._key).decode("ascii")
+            self._key = b64encode(self._key.encode("latin-1")).decode("ascii")
 
             path = uri.path
             if not path:
@@ -198,10 +182,10 @@ class WebSocket(object):
             if not self._recv():
                 raise Exception("Socket closed unexpectedly")
 
-            if self._recv_buffer.find('\r\n\r\n'.encode("ascii")) == -1:
+            if self._recv_buffer.find(b'\r\n\r\n') == -1:
                 raise WebSocketWantReadError
 
-            (request, self._recv_buffer) = self._recv_buffer.split('\r\n'.encode("ascii"), 1)
+            (request, self._recv_buffer) = self._recv_buffer.split(b'\r\n', 1)
             request = request.decode("latin-1")
 
             words = request.split()
@@ -210,7 +194,7 @@ class WebSocket(object):
             if words[1] != "101":
                 raise Exception("WebSocket request denied: %s" % " ".join(words[1:]))
 
-            (headers, self._recv_buffer) = self._recv_buffer.split('\r\n\r\n'.encode("ascii"), 1)
+            (headers, self._recv_buffer) = self._recv_buffer.split(b'\r\n\r\n', 1)
             headers = headers.decode('latin-1') + '\r\n'
             headers = email.message_from_string(headers)
 
@@ -463,7 +447,7 @@ class WebSocket(object):
 
         return len(msg)
 
-    def ping(self, data=''.encode('ascii')):
+    def ping(self, data=b''):
         """Write a ping message to the WebSocket
 
         WebSocketWantWriteError can be raised if there is insufficient
@@ -488,7 +472,7 @@ class WebSocket(object):
             self._previous_sendmsg = data
             raise
 
-    def pong(self, data=''.encode('ascii')):
+    def pong(self, data=b''):
         """Write a pong message to the WebSocket
 
         WebSocketWantWriteError can be raised if there is insufficient
@@ -542,7 +526,7 @@ class WebSocket(object):
 
         self._sent_close = True
 
-        msg = ''.encode('ascii')
+        msg = b''
         if code is not None:
             msg += struct.pack(">H", code)
             if reason is not None:
@@ -571,16 +555,9 @@ class WebSocket(object):
         while True:
             try:
                 data = self.socket.recv(4096)
-            except (socket.error, OSError):
-                exc = sys.exc_info()[1]
-                if hasattr(exc, 'errno'):
-                    err = exc.errno
-                else:
-                    err = exc[0]
-
-                if err == errno.EWOULDBLOCK:
+            except OSError as exc:
+                if exc.errno == errno.EWOULDBLOCK:
                     raise WebSocketWantReadError
-
                 raise
 
             if len(data) == 0:
@@ -637,7 +614,7 @@ class WebSocket(object):
 
                 if frame["fin"]:
                     msg = self._partial_msg
-                    self._partial_msg = ''.encode("ascii")
+                    self._partial_msg = b''
                     return msg
             elif frame["opcode"] == 0x1:
                 self.shutdown(socket.SHUT_RDWR, 1003, "Unsupported: Text frames are not supported")
@@ -712,16 +689,9 @@ class WebSocket(object):
 
         try:
             sent = self.socket.send(self._send_buffer)
-        except (socket.error, OSError):
-            exc = sys.exc_info()[1]
-            if hasattr(exc, 'errno'):
-                err = exc.errno
-            else:
-                err = exc[0]
-
-            if err == errno.EWOULDBLOCK:
+        except OSError as exc:
+            if exc.errno == errno.EWOULDBLOCK:
                 raise WebSocketWantWriteError
-
             raise
 
         self._send_buffer = self._send_buffer[sent:]
@@ -747,11 +717,9 @@ class WebSocket(object):
     def _sendmsg(self, opcode, msg):
         # Sends a standard data message
         if self.client:
-            mask = ''
+            mask = b''
             for i in range(4):
-                mask += chr(random.randrange(256))
-            if sys.hexversion >= 0x3000000:
-                mask = bytes(mask, "latin-1")
+                mask += random.randrange(256)
             frame = self._encode_hybi(opcode, msg, mask)
         else:
             frame = self._encode_hybi(opcode, msg)
@@ -773,7 +741,7 @@ class WebSocket(object):
             plen = len(buf)
             pstart = 0
             pend = plen
-            b = c = ''.encode('ascii')
+            b = c = b''
             if plen >= 4:
                 dtype=numpy.dtype('<u4')
                 if sys.byteorder == 'big':
@@ -794,8 +762,6 @@ class WebSocket(object):
             return b + c
         else:
             # Slower fallback
-            if sys.hexversion < 0x3000000:
-                mask = [ ord(c) for c in mask ]
             data = array.array('B')
             data.fromstring(buf)
             for i in range(len(data)):

--- a/websockify/websocketserver.py
+++ b/websockify/websocketserver.py
@@ -8,12 +8,7 @@ Licensed under LGPL version 3 (see docs/LICENSE.LGPL-3)
 '''
 
 import sys
-
-# python 3.0 differences
-try:
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-except ImportError:
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from websockify.websocket import WebSocket, WebSocketWantReadError, WebSocketWantWriteError
 
@@ -42,12 +37,7 @@ class WebSocketRequestHandlerMixIn:
         self._real_do_GET = self.do_GET
         self.do_GET = self._websocket_do_GET
         try:
-            # super() only works for new style classes
-            if issubclass(WebSocketRequestHandlerMixIn, object):
-                super(WebSocketRequestHandlerMixIn, self).handle_one_request()
-            else:
-                # Assume handle_one_request() hasn't been overriden
-                BaseHTTPRequestHandler.handle_one_request(self)
+            super().handle_one_request()
         finally:
             self.do_GET = self._real_do_GET
 


### PR DESCRIPTION
RHEL 6 is EOL now, so there should be nothing major left that doesn't have Python 3 support. So let's clean things up and remove all legacy handling.