### PR TITLE
Added exp claim for JWT token

### DIFF
--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -129,6 +129,12 @@ class JWTTokenApi(BasePlugin):
 
                 parsed = json.loads(token.claims)
                 
+                if 'nbf' in parsed:
+                    # Not Before is present, so we need to check it
+                    if time.time() < parsed['nbf']:
+                        print('Token can not be used yet!', file=sys.stderr)
+                        return None
+
                 if 'exp' in parsed:
                     # Expiration time is present, so we need to check it
                     if time.time() > parsed['exp']:

--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 
 class BasePlugin():
     def __init__(self, src):
@@ -127,6 +128,12 @@ class JWTTokenApi(BasePlugin):
                     token = jwt.JWT(key=key, jwt=token.claims)
 
                 parsed = json.loads(token.claims)
+                
+                if 'exp' in parsed:
+                    # Expiration time is present, so we need to check it
+                    if time.time() > parsed['exp']:
+                        print('Token has expired!', file=sys.stderr)
+                        return None
 
                 return (parsed['host'], parsed['port'])
             except Exception as e:


### PR DESCRIPTION
Currently, JWT tokens are reusable and can be intercepted. By using Expiration Time registered claim, it is possible to let expire them.
