### PR TITLE
Explicitly install old wrapt on Python 3.4

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ jwcrypto
 six
 redis
 simplejson
+wrapt<=1.12.1;python_version<="3.4"


### PR DESCRIPTION
Something is broken in pip so it installs a wrapt that doesn't support
Python 3.4. Work around this by manually request a version that is known
to work.