### PR TITLE
Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,36 @@ before running `python3 setup.py install`.
 
 Afterwards, websockify should be available in your path. Run
 `websockify --help` to confirm it's installed correctly.
+
+
+### Running with Docker/Podman
+You can also run websockify using Docker, Podman, Singularity, udocker or
+your favourite container runtime that support OCI container images.
+
+The entrypoint of the image is the `run` command.
+
+To build the image:
+```
+cd docker
+docker build -t novnc/websockify .
+```
+
+Once built you can just launch it with the same
+arguments you would give to the `run` command and taking care of
+assigning the port mappings:
+```
+docker run -it --rm -p <port>:<container_port> novnc/websockify <container_port> <run_arguments>
+```
+
+For example to forward traffic from local port 7000 to 10.1.1.1:5902
+you can use:
+```
+docker run -it --rm -p 7000:80 novnc/websockify 80 10.1.1.1:5902
+```
+
+If you need to include files, like for example for the `--web` or `--cert`
+options you can just mount the required files in the `/data` volume and then
+you can reference them in the usual way:
+```
+docker run -it --rm -p 443:443 -v websockify-data:/data novnc/websockify --cert /data/self.pem --web /data/noVNC :443 --token-plugin TokenRedis --token-source myredis.local:6379 --ssl-only --ssl-version tlsv1_2
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.6
+
+ENV VERSION 0.10.0
+
+RUN mkdir -p /opt/websockify \
+    && curl -SL https://github.com/novnc/websockify/archive/refs/tags/v$VERSION.tar.gz \
+    | tar xzC /opt/websockify
+
+RUN python -m pip install 'numpy<1.17' redis simplejson jwcrypto
+
+VOLUME /data
+
+EXPOSE 80
+EXPOSE 443
+
+WORKDIR /opt/websockify
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["--help"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+set -e
+
+/opt/websockify/websockify-$VERSION/run "$@"


### PR DESCRIPTION
Adding support to run with docker/podman or any other compatible container runtime.

To simplify the upgrades, the container is built on the official python image, in this case python:3.6 but it would be very easy to move to a different python version.

The container is built using the latest official release. To generate the Dockerfile for a new release is as simple as to bump the VERSION variable.

I also kept the same dependencies as currently used in the CI process: numpy<1.17 redis simplejson jwcrypto.

Finally, the users can provide files using the standard /data volume (certificates, novnc).

If you create a dockerhub account, let's say it is named `novnc` then you can build the image with:
```
docker build -t novnc/websockify:0.10.0 .
docker push novnc/websockify:0.10.0
```

And then you can just update the README to point there, in the meanwhile I think it is useful to have the image accessible so users don't need to build it themselves again (since this precisely the main advantadge of using docker).