### PR TITLE
TokenRedis plugin improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name=name,
       install_requires=[
         'numpy', 'requests',
         'jwcrypto',
-        'redis', 'simplejson',
+        'redis',
         ],
       zip_safe=False,
       entry_points={

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 mock
 nose2
 six
+redis
 wrapt<=1.12.1;python_version<="3.4"

--- a/tests/test_token_plugins.py
+++ b/tests/test_token_plugins.py
@@ -203,3 +203,35 @@ class TokenRedisTestCase(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result[0], 'remote_host')
         self.assertEqual(result[1], 'remote_port')
+
+    def test_src_only_host(self):
+        plugin = TokenRedis('127.0.0.1')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 0)
+        self.assertEqual(plugin._password, None)
+
+    def test_src_with_host_port(self):
+        plugin = TokenRedis('127.0.0.1:1234')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 1234)
+        self.assertEqual(plugin._db, 0)
+        self.assertEqual(plugin._password, None)
+
+    def test_src_with_host_port_db(self):
+        plugin = TokenRedis('127.0.0.1:1234:2')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 1234)
+        self.assertEqual(plugin._db, 2)
+        self.assertEqual(plugin._password, None)
+
+    def test_src_with_host_port_db_pass(self):
+        plugin = TokenRedis('127.0.0.1:1234:2:verysecret')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 1234)
+        self.assertEqual(plugin._db, 2)
+        self.assertEqual(plugin._password, 'verysecret')

--- a/tests/test_token_plugins.py
+++ b/tests/test_token_plugins.py
@@ -204,6 +204,60 @@ class TokenRedisTestCase(unittest.TestCase):
         self.assertEqual(result[0], 'remote_host')
         self.assertEqual(result[1], 'remote_port')
 
+    @patch('redis.Redis')
+    def test_json_token_with_spaces(self, mock_redis):
+        plugin = TokenRedis('127.0.0.1:1234')
+
+        instance = mock_redis.return_value
+        instance.get.return_value = b' {"host": "remote_host:remote_port"} '
+
+        result = plugin.lookup('testhost')
+
+        instance.get.assert_called_once_with('testhost')
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], 'remote_host')
+        self.assertEqual(result[1], 'remote_port')
+
+    @patch('redis.Redis')
+    def test_text_token(self, mock_redis):
+        plugin = TokenRedis('127.0.0.1:1234')
+
+        instance = mock_redis.return_value
+        instance.get.return_value = b'remote_host:remote_port'
+
+        result = plugin.lookup('testhost')
+
+        instance.get.assert_called_once_with('testhost')
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], 'remote_host')
+        self.assertEqual(result[1], 'remote_port')
+
+    @patch('redis.Redis')
+    def test_text_token_with_spaces(self, mock_redis):
+        plugin = TokenRedis('127.0.0.1:1234')
+
+        instance = mock_redis.return_value
+        instance.get.return_value = b' remote_host:remote_port '
+
+        result = plugin.lookup('testhost')
+
+        instance.get.assert_called_once_with('testhost')
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], 'remote_host')
+        self.assertEqual(result[1], 'remote_port')
+
+    @patch('redis.Redis')
+    def test_invalid_token(self, mock_redis):
+        plugin = TokenRedis('127.0.0.1:1234')
+
+        instance = mock_redis.return_value
+        instance.get.return_value = b'{"host": "remote_host:remote_port"   '
+
+        result = plugin.lookup('testhost')
+
+        instance.get.assert_called_once_with('testhost')
+        self.assertIsNone(result)
+
     def test_src_only_host(self):
         plugin = TokenRedis('127.0.0.1')
 

--- a/tests/test_token_plugins.py
+++ b/tests/test_token_plugins.py
@@ -289,3 +289,67 @@ class TokenRedisTestCase(unittest.TestCase):
         self.assertEqual(plugin._port, 1234)
         self.assertEqual(plugin._db, 2)
         self.assertEqual(plugin._password, 'verysecret')
+
+    def test_src_with_host_empty_port_empty_db_pass(self):
+        plugin = TokenRedis('127.0.0.1:::verysecret')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 0)
+        self.assertEqual(plugin._password, 'verysecret')
+
+    def test_src_with_host_empty_port_empty_db_empty_pass(self):
+        plugin = TokenRedis('127.0.0.1:::')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 0)
+        self.assertEqual(plugin._password, None)
+
+    def test_src_with_host_empty_port_empty_db_no_pass(self):
+        plugin = TokenRedis('127.0.0.1::')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 0)
+        self.assertEqual(plugin._password, None)
+
+    def test_src_with_host_empty_port_no_db_no_pass(self):
+        plugin = TokenRedis('127.0.0.1:')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 0)
+        self.assertEqual(plugin._password, None)
+
+    def test_src_with_host_empty_port_db_no_pass(self):
+        plugin = TokenRedis('127.0.0.1::2')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 2)
+        self.assertEqual(plugin._password, None)
+
+    def test_src_with_host_port_empty_db_pass(self):
+        plugin = TokenRedis('127.0.0.1:1234::verysecret')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 1234)
+        self.assertEqual(plugin._db, 0)
+        self.assertEqual(plugin._password, 'verysecret')
+
+    def test_src_with_host_empty_port_db_pass(self):
+        plugin = TokenRedis('127.0.0.1::2:verysecret')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 2)
+        self.assertEqual(plugin._password, 'verysecret')
+
+    def test_src_with_host_empty_port_db_empty_pass(self):
+        plugin = TokenRedis('127.0.0.1::2:')
+
+        self.assertEqual(plugin._server, '127.0.0.1')
+        self.assertEqual(plugin._port, 6379)
+        self.assertEqual(plugin._db, 2)
+        self.assertEqual(plugin._password, None)

--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -163,16 +163,21 @@ class TokenRedis(BasePlugin):
 
         host[:port[:db[:password]]]
 
-    where port and password are optional.
+    where port, db and password are optional. If port or db are left empty
+    they will take its default value, ie. 6379 and 0 respectively.
 
     If your redis server is using the default port (6379) then you can use:
 
         my-redis-host
 
-    In case you need to authenticate with the redis server you will have to
-    specify also the port and db:
+    In case you need to authenticate with the redis server and you are using
+    the default database and port you can use:
 
-        my-redis-host:6379:0:verysecretpass
+        my-redis-host:::verysecretpass
+
+    In the more general case you will use:
+
+        my-redis-host:6380:1:verysecretpass
 
     The TokenRedis plugin expects the format of the target in one of these two
     formats:
@@ -218,10 +223,22 @@ class TokenRedis(BasePlugin):
                 self._server = fields[0]
             elif len(fields) == 2:
                 self._server, self._port = fields
+                if not self._port:
+                    self._port = 6379
             elif len(fields) == 3:
                 self._server, self._port, self._db = fields
+                if not self._port:
+                    self._port = 6379
+                if not self._db:
+                    self._db = 0
             elif len(fields) == 4:
                 self._server, self._port, self._db, self._password = fields
+                if not self._port:
+                    self._port = 6379
+                if not self._db:
+                    self._db = 0
+                if not self._password:
+                    self._password = None
             else:
                 raise ValueError
             self._port = int(self._port)

--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 import re
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -167,14 +168,13 @@ class TokenRedis():
     Spawn a test "server" using netcat
         nc -l 5000 -v
 
-    Note: you have to install also the 'redis' and 'simplejson' modules
-          pip install redis simplejson
+    Note: you have to install also the 'redis' module
+          pip install redis
     """
     def __init__(self, src):
         try:
             # import those ahead of time so we provide error earlier
             import redis
-            import simplejson
             self._server, self._port = src.split(":")
             logger.info("TokenRedis backend initilized (%s:%s)" %
                   (self._server, self._port))
@@ -183,15 +183,14 @@ class TokenRedis():
                   src)
             sys.exit()
         except ImportError:
-            logger.error("package redis or simplejson not found, are you sure you've installed them correctly?")
+            logger.error("package redis not found, are you sure you've installed them correctly?")
             sys.exit()
 
     def lookup(self, token):
         try:
             import redis
-            import simplejson
         except ImportError:
-            logger.error("package redis or simplejson not found, are you sure you've installed them correctly?")
+            logger.error("package redis not found, are you sure you've installed them correctly?")
             sys.exit()
 
         logger.info("resolving token '%s'" % token)
@@ -202,7 +201,7 @@ class TokenRedis():
         else:
             responseStr = stuff.decode("utf-8")
             logger.debug("response from redis : %s" % responseStr)
-            combo = simplejson.loads(responseStr)
+            combo = json.loads(responseStr)
             (host, port) = combo["host"].split(':')
             logger.debug("host: %s, port: %s" % (host,port))
             return [host, port]

--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -155,8 +155,25 @@ class JWTTokenApi(BasePlugin):
             logger.error("package jwcrypto not found, are you sure you've installed it correctly?")
             return None
 
-class TokenRedis():
-    """
+
+class TokenRedis(BasePlugin):
+    """Token plugin based on the Redis in-memory data store.
+
+    The token source is in the format:
+
+        host[:port[:db[:password]]]
+
+    where port and password are optional.
+
+    If your redis server is using the default port (6379) then you can use:
+
+        my-redis-host
+
+    In case you need to authenticate with the redis server you will have to
+    specify also the port and db:
+
+        my-redis-host:6379:0:verysecretpass
+
     The TokenRedis plugin expects the format of the data in a form of json.
 
     Prepare data with:
@@ -173,17 +190,34 @@ class TokenRedis():
     """
     def __init__(self, src):
         try:
-            # import those ahead of time so we provide error earlier
             import redis
-            self._server, self._port = src.split(":")
+        except ImportError:
+            logger.error("Unable to load redis module")
+            sys.exit()
+        # Default values
+        self._port = 6379
+        self._db = 0
+        self._password = None
+        try:
+            fields = src.split(":")
+            if len(fields) == 1:
+                self._server = fields[0]
+            elif len(fields) == 2:
+                self._server, self._port = fields
+            elif len(fields) == 3:
+                self._server, self._port, self._db = fields
+            elif len(fields) == 4:
+                self._server, self._port, self._db, self._password = fields
+            else:
+                raise ValueError
+            self._port = int(self._port)
+            self._db = int(self._db)
             logger.info("TokenRedis backend initilized (%s:%s)" %
                   (self._server, self._port))
         except ValueError:
-            logger.error("The provided --token-source='%s' is not in an expected format <host>:<port>" %
-                  src)
-            sys.exit()
-        except ImportError:
-            logger.error("package redis not found, are you sure you've installed them correctly?")
+            logger.error("The provided --token-source='%s' is not in the "
+                         "expected format <host>[:<port>[:<db>[:<password>]]]" %
+                         src)
             sys.exit()
 
     def lookup(self, token):
@@ -194,7 +228,8 @@ class TokenRedis():
             sys.exit()
 
         logger.info("resolving token '%s'" % token)
-        client = redis.Redis(host=self._server, port=self._port)
+        client = redis.Redis(host=self._server, port=self._port,
+                             db=self._db, password=self._password)
         stuff = client.get(token)
         if stuff is None:
             return None


### PR DESCRIPTION
Various improvements to the TokenRedis plugin maintaining backwards compatibility:
- Support for password protected redis servers
- Support to select the redis database to use
- Support both for json and text format tokens (json seems a bit of an overhead in most cases)
- Verification of the token decoding and return None in case of a decoding error
- Eliminate the dependency with simplejson module since the json module in the standard lib is more than enough for our basic usage of using the loads
- Additional tests to verify all the functionality