### PR TITLE
Make wrap_cmd work as a simple run when using unix sockets

### DIFF
--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -302,7 +302,7 @@ class WebSocketProxy(websockifyserver.WebSockifyServer):
         # Last 3 timestamps command was run
         self.wrap_times    = [0, 0, 0]
 
-        if self.wrap_cmd:
+        if self.wrap_cmd and not self.unix_target:
             wsdir = os.path.dirname(sys.argv[0])
             rebinder_path = [os.path.join(wsdir, "..", "lib"),
                              os.path.join(wsdir, "..", "lib", "websockify"),
@@ -644,7 +644,7 @@ def websockify_init():
     del opts.target_cfg
 
     if sys.argv.count('--'):
-        opts.wrap_cmd = args[1:]
+        opts.wrap_cmd = args if opts.unix_listen else args[1:]
     else:
         opts.wrap_cmd = None
 


### PR DESCRIPTION
If unix-target is specified, don't use rebind (fixes a crash when accessing target_port).  If unix-listen is specified, there is no port argument to skip.

Currently if you specify a wrap_cmd along with a unix_listen socket or a unix_target, things break because of the lack of port.  Admittedly there is little reason to use wrap_cmd in this case because you could just run it separately, but it's still a convenient to just run the command.