### PR TITLE
Support for .htpasswd Authentication in BasicHTTPAuth (auth_plugin)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(name=name,
         'jwcrypto',
         'redis',
         ],
+      extras_requires={
+        'bcrypt': ['bcrypt']
+      },
       zip_safe=False,
       entry_points={
         'console_scripts': [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ nose2
 six
 redis
 wrapt<=1.12.1;python_version<="3.4"
+bcrypt

--- a/tests/test_auth_plugins.htpasswd
+++ b/tests/test_auth_plugins.htpasswd
@@ -1,0 +1,1 @@
+Aladdin:$2y$05$HKv0EhIJvZk6sMPSQEkPXuvjmkrtokn2Lv9CmQfpqkyEHRCy/NAdi

--- a/tests/test_auth_plugins.py
+++ b/tests/test_auth_plugins.py
@@ -26,3 +26,25 @@ class BasicHTTPAuthTestCase(unittest.TestCase):
     def test_garbage_auth(self):
         headers = {'Authorization': 'Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxx'}
         self.assertRaises(AuthenticationError, self.plugin.authenticate, headers, 'localhost', '1234')
+
+class BasicHTTPAuthWithHTPasswdTestCase(unittest.TestCase):
+
+    def setUp(self):
+        #file generated with `htpasswd -cBi test_auth_plugins.htpasswd Aladdin <<<"""open sesame\nopen sesame"""`
+        self.plugin = BasicHTTPAuth('./test_auth_plugins.htpasswd')
+
+    def test_no_auth(self):
+        headers = {}
+        self.assertRaises(AuthenticationError, self.plugin.authenticate, headers, 'localhost', '1234')
+
+    def test_invalid_password(self):
+        headers = {'Authorization': 'Basic QWxhZGRpbjpzZXNhbWUgc3RyZWV0'}
+        self.assertRaises(AuthenticationError, self.plugin.authenticate, headers, 'localhost', '1234')
+
+    def test_valid_password(self):
+        headers = {'Authorization': 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='}
+        self.plugin.authenticate(headers, 'localhost', '1234')
+
+    def test_garbage_auth(self):
+        headers = {'Authorization': 'Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxx'}
+        self.assertRaises(AuthenticationError, self.plugin.authenticate, headers, 'localhost', '1234')

--- a/websockify/auth_plugins.py
+++ b/websockify/auth_plugins.py
@@ -1,3 +1,5 @@
+import bcrypt
+
 class BasePlugin():
     def __init__(self, src=None):
         self.source = src
@@ -66,8 +68,20 @@ class BasicHTTPAuth():
     def validate_creds(self, username, password):
         if '%s:%s' % (username, password) == self.src:
             return True
-        else:
+        if not self.src:
             return False
+        try:
+            with open(self.src, 'r') as file:
+                for line in file:
+                    stored_user, stored_hash = line.strip().split(':', 1)
+                    if stored_user == username:
+                        encoded_password = password.encode("utf-8")
+                        encoded_hash = stored_hash.encode("utf-8")
+                        return bcrypt.checkpw(password, stored_hash)
+        except (FileNotFoundError, PermissionError, OSError, ValueError) as e:
+            #log error "%s: %s" % (type(e).__name__, e)
+            raise AuthenticationError(response_code=500, response_msg=f"Internal Server Error")
+        return False
 
     def auth_error(self):
         raise AuthenticationError(response_code=403)


### PR DESCRIPTION
This is a draft PR that implements using a `.htpsswd` file to authenticate against the server.
Is it connected to #590. It also allows to authenticate multiple users. This change tries to be backward-compatible, so existing functionalities won't be affected.

Changes:
- Updated `validate_creds()` to read the `.htpasswd` file specified by `--auth-source`.
- Implemented password verification using the *[bcrypt](https://pypi.org/project/bcrypt/)* library to handle hashed passwords.
- Added *[bcrypt](https://pypi.org/project/bcrypt/)* as a dependency in `setup.py`.
- Added a test that use the new mechanism