### PR TITLE
Fix outdated tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py3
 
 [testenv]
-commands = nosetests {posargs}
+commands = nose2 {posargs}
 deps = -r{toxinidir}/test-requirements.txt
 
 # At some point we should enable this since tox expects it to exist but

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34
+envlist = py3
 
 [testenv]
 commands = nosetests {posargs}


### PR DESCRIPTION
Update the default environment and test command so that we can run unit tests by the tox command properly.